### PR TITLE
fix(ci): install ripgrep for memory search tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,9 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v4
 
+      - name: Install ripgrep
+        run: sudo apt-get update && sudo apt-get install -y ripgrep
+
       - name: Create venv and install dependencies
         run: uv venv && uv pip install -e '.[test,lint]'
 


### PR DESCRIPTION
## Summary
- Install `ripgrep` on CI runner (`sudo apt-get install -y ripgrep`) so the `memory search` CLI command works in tests
- The `rg` binary is required by `lerim memory search` but isn't available on `ubuntu-latest` by default

## Test plan
- [ ] CI `unit-tests` job passes (previously failing with `FileNotFoundError: [Errno 2] No such file or directory: 'rg'`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)