### PR TITLE
chore: release v0.1.68

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.68] - 2026-03-21
+
+### Added
+
+- **Server readiness check on `lerim up`**: `cli.py` now polls `/api/health` for up to 30 seconds after starting the container, printing a clear warning if the server never responds.
+- **`pytest-timeout`** added to the `[test]` optional dependency group for controlled test execution time.
+- **`MINIMAX_API_KEY`** added to the environment-variable look-up list in the HTTP API.
+
+### Fixed
+
+- **Docker dashboard path**: `dashboard.py` resolves the dashboard directory correctly inside containers by falling back to `/opt/lerim/dashboard` when the repo-relative path does not exist. A corresponding `COPY dashboard/` step is added to the `Dockerfile`.
+- **Test `pythonpath`**: `[tool.pytest.ini_options]` now includes `pythonpath = ["."]` so `from tests.helpers import ...` resolves when running `uv run pytest`.
+- **HTTP API key list**: `_API_KEY_ENV_NAMES` is sorted alphabetically and now includes `ANTHROPIC_API_KEY` and `MINIMAX_API_KEY`.
+
 ## [0.1.66] - 2026-03-15
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends curl ripgrep &&
 COPY . /build
 RUN pip install --no-cache-dir /build && rm -rf /build
 
+# Dashboard assets for the built-in web UI
+COPY dashboard/ /opt/lerim/dashboard/
+
 EXPOSE 8765
 
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "lerim"
-version = "0.1.67"
+version = "0.1.68"
 description = "Continual learning layer for coding agents and software projects."
 readme = "README.md"
 requires-python = ">=3.10"
@@ -65,6 +65,7 @@ include = ["lerim*"]
 lerim = ["config/default.toml", "skills/*.md"]
 
 [tool.pytest.ini_options]
+pythonpath = ["."]
 testpaths = ["tests/unit", "tests/smoke", "tests/integration", "tests/e2e"]
 markers = [
     "integration: Tests that hit real external services",

--- a/src/lerim/app/api.py
+++ b/src/lerim/app/api.py
@@ -251,10 +251,11 @@ GHCR_IMAGE = "ghcr.io/lerim-dev/lerim-cli"
 
 
 _API_KEY_ENV_NAMES = (
-    "ZAI_API_KEY",
-    "OPENROUTER_API_KEY",
-    "OPENAI_API_KEY",
     "ANTHROPIC_API_KEY",
+    "MINIMAX_API_KEY",
+    "OPENAI_API_KEY",
+    "OPENROUTER_API_KEY",
+    "ZAI_API_KEY",
 )
 
 

--- a/src/lerim/app/cli.py
+++ b/src/lerim/app/cli.py
@@ -86,6 +86,22 @@ def _not_running() -> int:
     return 1
 
 
+def _wait_for_ready(port: int, timeout: int = 30) -> bool:
+	"""Poll /api/health until the server responds or *timeout* seconds elapse."""
+	url = f"http://localhost:{port}/api/health"
+	deadline = time.monotonic() + timeout
+	while time.monotonic() < deadline:
+		try:
+			req = urllib.request.Request(url, method="GET")
+			with urllib.request.urlopen(req, timeout=5) as resp:
+				if resp.status == 200:
+					return True
+		except (urllib.error.URLError, OSError):
+			pass
+		time.sleep(1)
+	return False
+
+
 def _api_get(path: str) -> dict[str, Any] | None:
     """GET from the running Lerim server. Returns None if not reachable."""
     config = get_config()
@@ -476,17 +492,26 @@ def _cmd_project(args: argparse.Namespace) -> int:
 
 
 def _cmd_up(args: argparse.Namespace) -> int:
-    """Start the Docker container."""
-    config = get_config()
-    _emit(
-        f"Starting Lerim with {len(config.projects)} projects and {len(config.agents)} agents..."
-    )
-    result = api_up(build_local=getattr(args, "build", False))
-    if result.get("error"):
-        _emit(result["error"], file=sys.stderr)
-        return 1
-    _emit(f"Lerim is running at http://localhost:{config.server_port}")
-    return 0
+	"""Start the Docker container."""
+	config = get_config()
+	_emit(
+		f"Starting Lerim with {len(config.projects)} projects and {len(config.agents)} agents..."
+	)
+	result = api_up(build_local=getattr(args, "build", False))
+	if result.get("error"):
+		_emit(result["error"], file=sys.stderr)
+		return 1
+
+	if not _wait_for_ready(config.server_port):
+		_emit(
+			"Container started but the server is not responding. "
+			"Check logs with: lerim logs",
+			file=sys.stderr,
+		)
+		return 1
+
+	_emit(f"Lerim is running at http://localhost:{config.server_port}")
+	return 0
 
 
 def _cmd_down(args: argparse.Namespace) -> int:

--- a/src/lerim/app/dashboard.py
+++ b/src/lerim/app/dashboard.py
@@ -52,8 +52,8 @@ from lerim.sessions.catalog import (
 )
 
 
-REPO_ROOT = Path(__file__).resolve().parents[3]
-DASHBOARD_DIR = REPO_ROOT / "dashboard"
+_REPO_DASHBOARD = Path(__file__).resolve().parents[3] / "dashboard"
+DASHBOARD_DIR = _REPO_DASHBOARD if _REPO_DASHBOARD.is_dir() else Path("/opt/lerim/dashboard")
 MAX_BODY_BYTES = 1_000_000
 READ_ONLY_MESSAGE = "Dashboard is read-only. Use CLI commands for write actions."
 _REPORT_CACHE: dict[str, Any] = {"at": None, "value": None}

--- a/uv.lock
+++ b/uv.lock
@@ -2983,7 +2983,7 @@ wheels = [
 
 [[package]]
 name = "lerim"
-version = "0.1.60"
+version = "0.1.68"
 source = { editable = "." }
 dependencies = [
     { name = "dspy" },
@@ -3019,6 +3019,7 @@ lint = [
 test = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "pytest-timeout" },
     { name = "pytest-xdist" },
 ]
 
@@ -3044,6 +3045,7 @@ requires-dist = [
     { name = "pydantic-ai", specifier = ">=1.61.0" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=8.0" },
     { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=0.24" },
+    { name = "pytest-timeout", marker = "extra == 'test'", specifier = ">=2.4" },
     { name = "pytest-xdist", marker = "extra == 'test'", specifier = ">=3.5" },
     { name = "python-dotenv", specifier = ">=1.2.1" },
     { name = "python-frontmatter", specifier = ">=1.1.0" },
@@ -5571,6 +5573,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
+]
+
+[[package]]
+name = "pytest-timeout"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/82/4c9ecabab13363e72d880f2fb504c5f750433b2b6f16e99f4ec21ada284c/pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a", size = 17973, upload-time = "2025-05-05T19:44:34.99Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2", size = 14382, upload-time = "2025-05-05T19:44:33.502Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- **Docker**: copy dashboard assets into image, fix path resolution for containers
- **CLI**: add server readiness check on `lerim up` (polls `/api/health` for up to 30s)
- **API**: sort env var look-up alphabetically, add `MINIMAX_API_KEY`
- **Pytest**: add `pythonpath = ["."]` so test imports resolve, add `pytest-timeout` dep
- **Version bump** to `0.1.68` with full changelog