### PR TITLE
fix: remove local AGENTS doc from unit contract test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.81] - 2026-04-29
+
+### Fixed
+- Unit docs-contract tests no longer require a repo-local `AGENTS.md`; the authoritative agent tool contract check now only reads committed public docs.
+
 ## [0.1.80] - 2026-04-29
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "lerim"
-version = "0.1.80"
+version = "0.1.81"
 description = "Continual learning layer for coding agents and software projects."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/unit/agents/test_agent_build.py
+++ b/tests/unit/agents/test_agent_build.py
@@ -22,7 +22,6 @@ from lerim.agents.maintain import (
     MaintainResult,
 )
 AUTHORITATIVE_TOOL_DOCS = (
-    "AGENTS.md",
     "README.md",
     "src/lerim/README.md",
     "tests/README.md",

--- a/uv.lock
+++ b/uv.lock
@@ -2645,7 +2645,7 @@ wheels = [
 
 [[package]]
 name = "lerim"
-version = "0.1.80"
+version = "0.1.81"
 source = { editable = "." }
 dependencies = [
     { name = "eval-type-backport", marker = "python_full_version < '3.13'" },


### PR DESCRIPTION
## Summary
- remove repo-local AGENTS.md from the committed docs contract test
- bump release metadata to v0.1.81

## Validation
- uv run python -m pytest tests/unit/agents/test_agent_build.py -q
- uv run ruff check src/ tests/
- uv run vulture src/lerim/ vulture_whitelist.py --min-confidence 60
- uv build --out-dir /private/tmp/lerim-v0.1.81-dist

Note: a full local unit run reached this fix and then hit a local stale ~/.lerim writer lock unrelated to CI.