### PR TITLE
Add generated Working Memory startup context

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Lerim fixes that by turning raw traces into reusable context records and making 
 - Local-first storage. Durable context lives in one global SQLite database at `~/.lerim/context.sqlite3`.
 - Shared across agents. What Claude Code learns can be reused by Codex, Cursor, or another supported agent later.
 - Background maintenance. `sync` ingests sessions, `maintain` consolidates overlap and archives stale records, `ask` retrieves relevant precedent.
+- Generated Working Memory. `working-memory` keeps a compact Markdown startup view at `~/.lerim/workspace/current/<project_id>/WORKING_MEMORY.md`.
 - Hybrid retrieval. Lerim combines local ONNX embeddings stored through `sqlite-vec` with SQLite FTS5 and RRF fusion.
 - Clean agent tool surface. The runtime exposes semantic DB-era tools like `list_context`, `search_context`, `get_context`, `save_context`, `revise_context`, and `count_context` instead of file CRUD.
 
@@ -131,6 +132,18 @@ Lets you ask questions against accumulated project context.
 lerim ask "Why did we choose SQLite for local metadata?"
 ```
 
+### `lerim working-memory`
+
+Reads or refreshes a generated Markdown startup context for the current project.
+This is the fast path a coding agent can read at the start of work without
+running retrieval or synthesis in real time.
+
+```bash
+lerim working-memory show
+lerim working-memory status
+lerim working-memory refresh
+```
+
 ## Configuration
 
 `lerim init` creates the default local configuration. You can override settings in:
@@ -165,7 +178,7 @@ fallback_models = ["zai:glm-4.7"]
 
 ## How It Works
 
-Lerim has three main flows:
+Lerim has four main flows:
 
 1. `sync`
    Reads new traces/session metadata and extracts durable context records.
@@ -175,6 +188,10 @@ Lerim has three main flows:
 
 3. `ask`
    Retrieves relevant records and answers a question using the current context layer.
+
+4. `working-memory`
+   Generates a compact, cited Markdown view from recent durable records so agents
+   can start with fast context before querying deeper.
 
 In practice, this means Lerim becomes the shared precedent store behind your agent workflows.
 
@@ -192,6 +209,7 @@ Global Lerim state lives under `~/.lerim/`:
 - `context.sqlite3` — canonical durable context store
 - `index/sessions.sqlite3` — session catalog and queue
 - `workspace/` — sync and maintain run artifacts
+- `workspace/current/<project_id>/WORKING_MEMORY.md` — generated current Working Memory view
 - `cache/traces/` — compacted agent trace cache
 - `models/embeddings/` — local embedding model cache
 - `models/huggingface/` — Hugging Face library cache
@@ -232,6 +250,8 @@ lerim queue
 lerim queue --failed
 lerim sync
 lerim maintain
+lerim working-memory show
+lerim working-memory status
 lerim ask "What decisions exist about caching?"
 ```
 

--- a/docs/cli/overview.md
+++ b/docs/cli/overview.md
@@ -18,6 +18,10 @@ These work on local files, Docker, or config:
 - `lerim skip`
 - `lerim skill`
 - `lerim auth`
+- `lerim working-memory show`
+- `lerim working-memory status`
+- `lerim working-memory path`
+- `lerim working-memory refresh`
 
 ## Server-backed commands
 
@@ -33,3 +37,7 @@ These talk to the running Lerim service:
 
 The CLI works with the global context database.
 Project commands register scope only.
+
+Working Memory is a generated Markdown view of the global context database. It
+is useful at agent startup, but `~/.lerim/context.sqlite3` remains the source of
+truth.

--- a/docs/cli/working-memory.md
+++ b/docs/cli/working-memory.md
@@ -19,8 +19,8 @@ lerim working-memory refresh --force
 
 | Subcommand | Description |
 |------------|-------------|
-| `show` | Print the current `WORKING_MEMORY.md` without model calls |
-| `status` | Print availability, generated time, age, included records, changed-record count, paths, latest run folder, and suggested action |
+| `show` | Print live DB freshness plus the current `WORKING_MEMORY.md` without model calls |
+| `status` | Print availability, generated time, age, included records, DB changed-record count, paths, latest run folder, and suggested action |
 | `path` | Print the stable expected current artifact path |
 | `refresh` | Generate dated artifacts and update the stable current copy when records changed |
 
@@ -41,6 +41,30 @@ lerim working-memory show --project lerim-cli
 lerim working-memory status --project ~/codes/my-app
 ```
 
+## Printed Output
+
+`show` prints a live DB freshness preface before the static markdown artifact.
+The preface is computed when `show` runs, so agents can see whether records
+changed after the snapshot was generated without triggering synthesis.
+
+The markdown artifact itself uses a fixed section order:
+
+1. `Summary`
+2. `Start Here`
+3. `Current Handoff`
+4. `Decisions`
+5. `Constraints & Preferences`
+6. `Project Facts`
+7. `Open Risks / Review Queue`
+8. `Follow-up Queries`
+9. `Sources`
+
+`Start Here` is deterministic repo/startup guidance rendered by Lerim, not
+model-written prose. `Current Handoff` is populated only from recent episode
+evidence; when recent episode evidence is absent, it says no implementation
+handoff is available from persisted records. Test/build claims inside the
+markdown are historical persisted evidence, not current verification.
+
 ## Output Location
 
 Current artifact:
@@ -60,14 +84,14 @@ Dated run artifacts:
 ```mermaid
 flowchart TD
     A["lerim working-memory refresh"] --> B["Resolve registered project"]
-    B --> C["Count records changed since current manifest generated_at"]
+    B --> C["Count DB records changed since current manifest generated_at"]
     C --> D{"Unchanged and current file exists?"}
     D -- "yes" --> E["Skip without model call"]
     D -- "no" --> F["Load active candidate records from SQLite"]
     F --> G{"Candidates exist?"}
     G -- "no" --> H["Render empty-state Markdown"]
     G -- "yes" --> I["Run Working Memory synthesis agent"]
-    I --> J["Validate cited record IDs"]
+    I --> J["Validate cited record IDs and fixed sections"]
     H --> K["Write dated run artifacts"]
     J --> K
     K --> L["Copy latest markdown and manifest to workspace/current"]
@@ -83,3 +107,7 @@ Working Memory is refreshed outside the sync hot path:
 - manual `refresh --force` bypasses the unchanged check
 
 See [Working Memory](../concepts/working-memory.md) for the architecture.
+
+`WORKING_MEMORY.md` is a static snapshot. Use the live preface from `show` or
+the JSON from `status` for current DB freshness. Test/build results inside the
+markdown are historical persisted evidence; rerun relevant checks after edits.

--- a/docs/cli/working-memory.md
+++ b/docs/cli/working-memory.md
@@ -1,0 +1,85 @@
+# lerim working-memory
+
+`lerim working-memory` reads or refreshes generated startup context for the
+resolved project.
+
+It is host-only for `show`, `status`, and `path`. `refresh` runs local
+generation and records a service run. The generated Markdown is a derived view
+of `~/.lerim/context.sqlite3`.
+
+## Commands
+
+```bash
+lerim working-memory show
+lerim working-memory status
+lerim working-memory path
+lerim working-memory refresh
+lerim working-memory refresh --force
+```
+
+| Subcommand | Description |
+|------------|-------------|
+| `show` | Print the current `WORKING_MEMORY.md` without model calls |
+| `status` | Print availability, generated time, age, included records, changed-record count, paths, latest run folder, and suggested action |
+| `path` | Print the stable expected current artifact path |
+| `refresh` | Generate dated artifacts and update the stable current copy when records changed |
+
+| Flag | Description |
+|------|-------------|
+| `--project` | Registered project name or path. Defaults to the project resolved from cwd |
+| `--force` | On `refresh`, regenerate even when no context records changed |
+| `--json` | Emit structured JSON for `status`, `path`, and `refresh` |
+
+## Project Resolution
+
+Agents should not hardcode project IDs. Lerim resolves the project from the
+current directory by matching registered project paths. If the command is run
+outside the repository, pass a registered project name or path:
+
+```bash
+lerim working-memory show --project lerim-cli
+lerim working-memory status --project ~/codes/my-app
+```
+
+## Output Location
+
+Current artifact:
+
+```text
+~/.lerim/workspace/current/<project_id>/WORKING_MEMORY.md
+```
+
+Dated run artifacts:
+
+```text
+~/.lerim/workspace/YYYY/MM/DD/working-memory/working-memory-<timestamp>-<id>/
+```
+
+## Generation Flow
+
+```mermaid
+flowchart TD
+    A["lerim working-memory refresh"] --> B["Resolve registered project"]
+    B --> C["Count records changed since current manifest generated_at"]
+    C --> D{"Unchanged and current file exists?"}
+    D -- "yes" --> E["Skip without model call"]
+    D -- "no" --> F["Load active candidate records from SQLite"]
+    F --> G{"Candidates exist?"}
+    G -- "no" --> H["Render empty-state Markdown"]
+    G -- "yes" --> I["Run Working Memory synthesis agent"]
+    I --> J["Validate cited record IDs"]
+    H --> K["Write dated run artifacts"]
+    J --> K
+    K --> L["Copy latest markdown and manifest to workspace/current"]
+```
+
+## Automation
+
+Working Memory is refreshed outside the sync hot path:
+
+- the daemon runs a daily pass for all registered projects
+- `maintain` runs it only for projects whose records changed
+- unchanged projects are skipped
+- manual `refresh --force` bypasses the unchanged check
+
+See [Working Memory](../concepts/working-memory.md) for the architecture.

--- a/docs/concepts/how-it-works.md
+++ b/docs/concepts/how-it-works.md
@@ -10,7 +10,8 @@ The flow is:
 2. traces are normalized
 3. `sync` extracts durable context records
 4. `maintain` cleans and supersedes records
-5. `ask` retrieves records and answers questions
+5. `working-memory` generates fast startup context from records
+6. `ask` retrieves records and answers questions
 
 For operational targets and scale boundaries, see
 [Capacity and SLOs](capacity-and-slos.md).
@@ -69,6 +70,22 @@ Search indexes are derived, not canonical:
 - If counts diverge, `ask` can still run, but retrieval is operationally
   degraded until maintenance or write-time refresh rebuilds derived rows from
   canonical records.
+
+## Working Memory
+
+Working Memory is also derived, not canonical. It renders a compact
+`WORKING_MEMORY.md` from active project records so a coding agent can start with
+fast context and then query deeper only when needed.
+
+```mermaid
+flowchart LR
+    A["context.sqlite3 records"] --> B["Working Memory synthesis"]
+    B --> C["dated run artifacts"]
+    C --> D["workspace/current/<project_id>/WORKING_MEMORY.md"]
+    D --> E["coding agent startup"]
+```
+
+See [Working Memory](working-memory.md) for the full generation flow.
 
 ## Why this design
 

--- a/docs/concepts/sync-maintain.md
+++ b/docs/concepts/sync-maintain.md
@@ -75,14 +75,20 @@ The maintain and ask flows use explicit request-turn budgets from config:
 
 ## Automatic scheduling
 
-The daemon runs sync and maintain on independent intervals:
+The daemon runs sync, maintain, and Working Memory on independent schedules:
 
 | Path | Config key | Default (see `default.toml`) |
 |------|------------|---------|
 | Sync | `sync_interval_minutes` | `30` |
 | Maintain | `maintain_interval_minutes` | `60` |
+| Working Memory | built-in daily pass | `24h` |
 
-Both trigger immediately on daemon startup, then repeat at their configured intervals.
+Sync and maintain trigger immediately on daemon startup, then repeat at their
+configured intervals. Working Memory also runs from the daemon loop, but it
+skips projects with no records changed since the current artifact was generated.
+
+Maintain also triggers Working Memory for a project when maintain changed records
+for that project. Sync does not directly trigger Working Memory.
 
 ### Local model memory management
 
@@ -96,6 +102,8 @@ lerim sync --run-id <id>             # sync a specific session
 lerim sync --dry-run                 # preview without writing
 lerim maintain                       # run maintain cycle
 lerim maintain --dry-run             # preview without writing
+lerim working-memory status          # check generated startup context
+lerim working-memory refresh         # refresh only if records changed
 ```
 
 ---

--- a/docs/concepts/working-memory.md
+++ b/docs/concepts/working-memory.md
@@ -6,6 +6,10 @@ It is a generated Markdown view of durable SQLite context records. It is not a
 second memory store, and agents should not edit it by hand. The source of truth
 remains `~/.lerim/context.sqlite3`.
 
+`lerim working-memory show` prepends live DB freshness before printing the
+current markdown snapshot. The preface is current at read time; the markdown is
+the last generated artifact.
+
 The current view lives at:
 
 ```text
@@ -22,12 +26,12 @@ pass `--project <name-or-path>`.
 flowchart TD
     A["Coding agent starts work"] --> B["lerim working-memory show"]
     B --> C{"Current artifact exists?"}
-    C -- "yes" --> D["Read WORKING_MEMORY.md"]
+    C -- "yes" --> D["Read live freshness preface and WORKING_MEMORY.md"]
     C -- "no" --> E["Use lerim working-memory status"]
     E --> F["Suggested action: refresh"]
     D --> G{"Need deeper or newer context?"}
     G -- "yes" --> H["lerim working-memory status"]
-    H --> I{"Records changed since generation?"}
+    H --> I{"DB records changed since generation?"}
     I -- "yes" --> J["lerim working-memory refresh"]
     I -- "no" --> K["Use lerim query or lerim ask for deeper lookup"]
     G -- "no" --> L["Proceed with coding"]
@@ -53,7 +57,7 @@ flowchart TD
     J -- "yes" --> L["Working Memory synthesis agent"]
     L --> M["PydanticAI agent with low-variance settings"]
     M --> N["Structured output: summary sections and cited lines"]
-    N --> O["Validate every line cites known record IDs"]
+    N --> O["Validate every line cites known record IDs and fixed sections"]
     K --> P["Render Markdown"]
     O --> P
     P --> Q["Write run artifacts: WORKING_MEMORY.md, manifest, events, agent log, trace"]
@@ -67,9 +71,11 @@ The Working Memory feature has two layers:
 
 - `lerim.working_memory` owns deterministic use-case logic: project resolution,
   changed-record detection, candidate loading, validation, rendering, manifests,
-  status, and artifact paths.
+  status, artifact paths, deterministic `Start Here`, fixed section order, and
+  live freshness prefaces.
 - `lerim.agents.working_memory` owns model synthesis only. It receives bounded
-  candidate records and returns structured cited lines.
+  candidate records and returns structured cited lines for the model-filled
+  sections.
 
 `LerimRuntime.working_memory()` ties those layers together. The daemon calls the
 runtime for all registered projects during the daily pass, and after `maintain`
@@ -80,6 +86,7 @@ only when maintain changed records.
 Working Memory refresh is intentionally not part of the sync hot path.
 
 - `lerim working-memory show`, `status`, and `path` are fast local reads.
+- `show` prepends live DB freshness before printing the static markdown snapshot.
 - `lerim working-memory refresh` generates only when records changed, unless
   `--force` is passed.
 - The daemon runs a daily pass across registered projects and skips unchanged
@@ -87,6 +94,34 @@ Working Memory refresh is intentionally not part of the sync hot path.
 - `maintain` triggers Working Memory only when it merged, archived,
   consolidated, or otherwise changed records.
 - Empty projects get an empty-state Markdown file without a model call.
+
+## Fixed Markdown Shape
+
+Generated Working Memory has a stable section order so agents can scan it
+predictably:
+
+1. `Summary`
+2. `Start Here`
+3. `Current Handoff`
+4. `Decisions`
+5. `Constraints & Preferences`
+6. `Project Facts`
+7. `Open Risks / Review Queue`
+8. `Follow-up Queries`
+9. `Sources`
+
+`Summary` is the compact startup cache. `Start Here` is deterministic and
+rendered by Lerim from project metadata and artifact status. `Current Handoff`
+must come only from recent episode evidence; without that evidence, it should
+explicitly say no persisted implementation handoff is available and point agents
+back to the current chat, git state, and tests for live work.
+
+`Decisions`, `Constraints & Preferences`, and `Project Facts` hold durable
+records. `Open Risks / Review Queue` and `Follow-up Queries` are populated only
+from records that explicitly describe unresolved work, review concerns, or
+questions worth asking next. `Sources` lists the cited record IDs used in the
+body. Any test/build result in these sections is historical persisted evidence;
+agents must rerun relevant checks after making edits.
 
 ## Artifact Layout
 
@@ -110,7 +145,8 @@ The latest successful run is copied to the stable current path:
 ```
 
 The manifest records the project, `project_id`, run folder, generated time,
-candidate count, included record IDs, and changed-record count.
+previous generation time, trigger, candidate count, included record IDs, and
+changed-record count before generation.
 
 ## What Agents Should Do
 
@@ -119,7 +155,7 @@ At startup, a coding agent should:
 1. Run `lerim working-memory show` from the repo.
 2. If the file is missing or the task depends on newest context, run
    `lerim working-memory status`.
-3. If status reports changed records, suggest or run
+3. If status reports changed DB records, suggest or run
    `lerim working-memory refresh`.
 4. Use `lerim query` for exact inspection and `lerim ask` for synthesized
    answers across more context.

--- a/docs/concepts/working-memory.md
+++ b/docs/concepts/working-memory.md
@@ -1,0 +1,125 @@
+# Working Memory
+
+Working Memory is Lerim's fast startup context for coding agents.
+
+It is a generated Markdown view of durable SQLite context records. It is not a
+second memory store, and agents should not edit it by hand. The source of truth
+remains `~/.lerim/context.sqlite3`.
+
+The current view lives at:
+
+```text
+~/.lerim/workspace/current/<project_id>/WORKING_MEMORY.md
+```
+
+Agents do not need to know `<project_id>` ahead of time. They should run
+`lerim working-memory show`, `status`, or `path` from inside the repository, or
+pass `--project <name-or-path>`.
+
+## Flow
+
+```mermaid
+flowchart TD
+    A["Coding agent starts work"] --> B["lerim working-memory show"]
+    B --> C{"Current artifact exists?"}
+    C -- "yes" --> D["Read WORKING_MEMORY.md"]
+    C -- "no" --> E["Use lerim working-memory status"]
+    E --> F["Suggested action: refresh"]
+    D --> G{"Need deeper or newer context?"}
+    G -- "yes" --> H["lerim working-memory status"]
+    H --> I{"Records changed since generation?"}
+    I -- "yes" --> J["lerim working-memory refresh"]
+    I -- "no" --> K["Use lerim query or lerim ask for deeper lookup"]
+    G -- "no" --> L["Proceed with coding"]
+    J --> M["Runtime generates dated artifacts"]
+    M --> N["Copy latest markdown and manifest to workspace/current"]
+    N --> D
+```
+
+## Generation Architecture
+
+```mermaid
+flowchart TD
+    A["Trigger: manual refresh, daily daemon, or maintain changed records"] --> B["Resolve project from cwd, name, or path"]
+    B --> C["Resolve project_id from repo path"]
+    C --> D["Read current manifest from workspace/current"]
+    D --> E["Count record_versions changed after previous generated_at"]
+    E --> F{"Current file exists and changed count is 0 and not --force?"}
+    F -- "yes" --> G["Return skipped result and record service run"]
+    F -- "no" --> H["Create dated run folder under workspace/YYYY/MM/DD/working-memory"]
+    H --> I["Load active candidate records from SQLite"]
+    I --> J{"Any candidates?"}
+    J -- "no" --> K["Build empty Working Memory draft without model call"]
+    J -- "yes" --> L["Working Memory synthesis agent"]
+    L --> M["PydanticAI agent with low-variance settings"]
+    M --> N["Structured output: summary sections and cited lines"]
+    N --> O["Validate every line cites known record IDs"]
+    K --> P["Render Markdown"]
+    O --> P
+    P --> Q["Write run artifacts: WORKING_MEMORY.md, manifest, events, agent log, trace"]
+    Q --> R["Copy WORKING_MEMORY.md and manifest into workspace/current/<project_id>"]
+    R --> S["Return generated result and record service run"]
+```
+
+## Agent Boundary
+
+The Working Memory feature has two layers:
+
+- `lerim.working_memory` owns deterministic use-case logic: project resolution,
+  changed-record detection, candidate loading, validation, rendering, manifests,
+  status, and artifact paths.
+- `lerim.agents.working_memory` owns model synthesis only. It receives bounded
+  candidate records and returns structured cited lines.
+
+`LerimRuntime.working_memory()` ties those layers together. The daemon calls the
+runtime for all registered projects during the daily pass, and after `maintain`
+only when maintain changed records.
+
+## Refresh Rules
+
+Working Memory refresh is intentionally not part of the sync hot path.
+
+- `lerim working-memory show`, `status`, and `path` are fast local reads.
+- `lerim working-memory refresh` generates only when records changed, unless
+  `--force` is passed.
+- The daemon runs a daily pass across registered projects and skips unchanged
+  projects.
+- `maintain` triggers Working Memory only when it merged, archived,
+  consolidated, or otherwise changed records.
+- Empty projects get an empty-state Markdown file without a model call.
+
+## Artifact Layout
+
+Each generation writes a dated run folder:
+
+```text
+~/.lerim/workspace/YYYY/MM/DD/working-memory/working-memory-<timestamp>-<id>/
+  WORKING_MEMORY.md
+  manifest.json
+  events.jsonl
+  agent.log
+  agent-trace.json
+```
+
+The latest successful run is copied to the stable current path:
+
+```text
+~/.lerim/workspace/current/<project_id>/
+  WORKING_MEMORY.md
+  manifest.json
+```
+
+The manifest records the project, `project_id`, run folder, generated time,
+candidate count, included record IDs, and changed-record count.
+
+## What Agents Should Do
+
+At startup, a coding agent should:
+
+1. Run `lerim working-memory show` from the repo.
+2. If the file is missing or the task depends on newest context, run
+   `lerim working-memory status`.
+3. If status reports changed records, suggest or run
+   `lerim working-memory refresh`.
+4. Use `lerim query` for exact inspection and `lerim ask` for synthesized
+   answers across more context.

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,4 +23,5 @@ The current architecture is simple:
 - [Installation](installation.md)
 - [Quickstart](quickstart.md)
 - [How It Works](concepts/how-it-works.md)
+- [Working Memory](concepts/working-memory.md)
 - [CLI Overview](cli/overview.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -98,6 +98,7 @@ nav:
     - Context Model: concepts/context-model.md
     - Supported Agents: concepts/supported-agents.md
     - Sync & Maintain: concepts/sync-maintain.md
+    - Working Memory: concepts/working-memory.md
   - CLI Reference:
     - Overview: cli/overview.md
     - lerim init: cli/init.md
@@ -106,6 +107,7 @@ nav:
     - lerim up / down / logs: cli/up-down-logs.md
     - lerim sync: cli/sync.md
     - lerim maintain: cli/maintain.md
+    - lerim working-memory: cli/working-memory.md
     - lerim ask: cli/ask.md
     - lerim query: cli/query.md
     - lerim queue: cli/queue.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "lerim"
-version = "0.1.81"
+version = "0.1.82"
 description = "Continual learning layer for coding agents and software projects."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/lerim/README.md
+++ b/src/lerim/README.md
@@ -9,7 +9,7 @@ Project identity is used to separate records by repo inside that shared DB.
 
 The package is organized by feature boundary:
 
-- `agents/`: agent flows (`extract.py`, `maintain.py`, `ask.py`), semantic context tools (`tools.py`), typed contracts (`contracts.py`)
+- `agents/`: agent flows (`extract.py`, `maintain.py`, `ask.py`, `working_memory.py`), semantic context tools (`tools.py`), typed contracts (`contracts.py`)
 - `server/`: CLI (`cli.py`), HTTP API (`httpd.py`), daemon (`daemon.py`), runtime orchestrator (`runtime.py`), Docker/runtime API helpers (`api.py`)
 - `config/`: config loading (`settings.py`), PydanticAI model builders (`providers.py`), tracing and logging setup
 - `context/`: global SQLite context store, ONNX embedding provider, `sqlite-vec` index management, and retrieval/write helpers
@@ -17,6 +17,7 @@ The package is organized by feature boundary:
 - `adapters/`: session readers for Claude, Codex, Cursor, OpenCode
 - `cloud/`: hosted auth/shipper integration (`auth.py`, `shipper.py`)
 - `skills/`: bundled skill markdown files
+- `working_memory.py`: deterministic Working Memory use-case logic, artifact paths, status, rendering, and validation
 
 ## How to use
 
@@ -25,7 +26,23 @@ If you are new to the codebase, read in this order:
 1. `server/cli.py` for the public command surface.
 2. `server/daemon.py` for sync/maintain scheduling and lock flow.
 3. `server/runtime.py` for runtime orchestration across extract/maintain/ask.
-4. `context/store.py` for the canonical SQLite schema and retrieval/write logic.
+4. `working_memory.py` and `agents/working_memory.py` for generated Working Memory.
+5. `context/store.py` for the canonical SQLite schema and retrieval/write logic.
    This is where hybrid search happens: local ONNX embeddings, `sqlite-vec` KNN, SQLite FTS5, and RRF fusion.
-5. `agents/tools.py` for the authoritative semantic agent tool surface (`read_trace`, `list_context`, `search_context`, `get_context`, `save_context`, `revise_context`, `archive_context`, `supersede_context`, `count_context`, `note_trace_findings`, `prune_trace_reads`).
-6. `agents/extract.py`, `agents/maintain.py`, `agents/ask.py` for PydanticAI agent behavior.
+6. `agents/tools.py` for the authoritative semantic agent tool surface (`read_trace`, `list_context`, `search_context`, `get_context`, `save_context`, `revise_context`, `archive_context`, `supersede_context`, `count_context`, `note_trace_findings`, `prune_trace_reads`).
+7. `agents/extract.py`, `agents/maintain.py`, `agents/ask.py` for PydanticAI agent behavior.
+
+## Working Memory flow
+
+```mermaid
+flowchart TD
+    A["CLI, daily daemon, or maintain trigger"] --> B["LerimRuntime.working_memory"]
+    B --> C["working_memory.py deterministic use case"]
+    C --> D{"Records changed since current manifest?"}
+    D -- "no" --> E["Skip"]
+    D -- "yes or --force" --> F["Load candidate records from SQLite"]
+    F --> G["agents/working_memory.py synthesis agent"]
+    G --> H["Validate cited output"]
+    H --> I["Render and write dated artifacts"]
+    I --> J["Copy current WORKING_MEMORY.md"]
+```

--- a/src/lerim/agents/contracts.py
+++ b/src/lerim/agents/contracts.py
@@ -44,6 +44,7 @@ class WorkingMemoryResultContract(BaseModel):
 	status: str
 	project: str
 	project_id: str
+	trigger: str = "manual"
 	generated_at: str | None = None
 	context_db_path: str
 	workspace_root: str

--- a/src/lerim/agents/contracts.py
+++ b/src/lerim/agents/contracts.py
@@ -38,6 +38,26 @@ class MaintainResultContract(BaseModel):
 	cost_usd: float = 0.0
 
 
+class WorkingMemoryResultContract(BaseModel):
+	"""Stable Working Memory refresh payload schema used by CLI and daemon."""
+
+	status: str
+	project: str
+	project_id: str
+	generated_at: str | None = None
+	context_db_path: str
+	workspace_root: str
+	run_folder: str | None = None
+	current_file: str
+	current_manifest: str
+	records_considered: int = 0
+	records_included: int = 0
+	records_changed_since_previous: int = 0
+	included_record_ids: list[str] = []
+	skip_reason: str | None = None
+	cost_usd: float = 0.0
+
+
 if __name__ == "__main__":
 	"""Run contract model smoke checks."""
 	sync = SyncResultContract(

--- a/src/lerim/agents/working_memory.py
+++ b/src/lerim/agents/working_memory.py
@@ -12,7 +12,7 @@ from pydantic_ai.usage import UsageLimits
 
 from lerim.agents.mlflow_observability import handle_mlflow_event_stream, mlflow_span
 from lerim.agents.model_settings import LOW_VARIANCE_AGENT_MODEL_SETTINGS
-from lerim.working_memory import MemoryLine, MemorySection, WorkingMemoryDraft
+from lerim.working_memory import MemoryLine, WorkingMemoryDraft
 
 
 WORKING_MEMORY_SYSTEM_PROMPT = """\
@@ -22,10 +22,24 @@ You write Lerim Working Memory for coding agents.
 
 <rules>
 - Use only the candidate records supplied in the prompt.
+- Optimize for a coding agent starting work in this repository right now.
+- Prefer actionability over completeness: include what changes decisions, commands, file paths, constraints, or next steps.
 - Prefer durable records: decision, preference, constraint, fact, reference.
-- Use episode records only for recent flow context or when no durable record covers the topic.
+- Use episode records for recent flow context, current work, open loops, and next commands.
+- If a record is a decision or fact, present it as established context, not as unfinished current work.
+- Produce the fixed fields: summary, start_here, current_handoff, decisions, constraints_preferences, project_facts, open_risks, follow_up_queries.
+- Every fixed field is a list of objects with text and record_ids. Use an empty list when records do not support a field.
+- Do not create Current Handoff, Open Risks, Next Steps, Open Concerns, or todo wording unless a cited candidate record explicitly supports unresolved, blocked, risky, requested-next, or recently-in-progress work.
+- Never say `lerim working-memory show` generates Working Memory. `show` only reads the current artifact. Generation happens through `refresh`, the daily daemon pass, or maintain-triggered refresh.
+- Avoid implementation minutiae unless they prevent mistakes or guide the next edit.
+- Make the summary a prioritized startup cache, not a table of contents.
+- If there are episode records, put the newest recent-flow or handoff fact first in the summary.
+- Treat test/build results from records as historical evidence with timestamps, not as current truth. Any line mentioning test, build, lint, typecheck, CI, or verification results must say "Persisted record says ..." and "rerun relevant tests after edits."
+- Avoid repeating the same memory across fields.
 - Keep the result compact enough for a roughly 50-line markdown file.
 - Every line must include at least one exact record_id from the supplied candidates.
+- record_ids must copy exact record_id strings from the candidate records; do not alter, normalize, shorten, or invent them.
+- Put record IDs only in the record_ids field, never in line text.
 - Do not quote long evidence. Compress and preserve the practical instruction or fact.
 - Do not invent current repository state beyond the stored records.
 </rules>
@@ -39,18 +53,17 @@ class WorkingMemoryLineOutput(BaseModel):
     record_ids: list[str] = Field(description="Exact source record IDs")
 
 
-class WorkingMemorySectionOutput(BaseModel):
-    """One named section in the generated Working Memory draft."""
-
-    title: str
-    lines: list[WorkingMemoryLineOutput]
-
-
 class WorkingMemoryOutput(BaseModel):
     """Structured output returned by the Working Memory synthesis agent."""
 
-    summary: list[WorkingMemoryLineOutput]
-    sections: list[WorkingMemorySectionOutput]
+    summary: list[WorkingMemoryLineOutput] = Field(default_factory=list)
+    start_here: list[WorkingMemoryLineOutput] = Field(default_factory=list)
+    current_handoff: list[WorkingMemoryLineOutput] = Field(default_factory=list)
+    decisions: list[WorkingMemoryLineOutput] = Field(default_factory=list)
+    constraints_preferences: list[WorkingMemoryLineOutput] = Field(default_factory=list)
+    project_facts: list[WorkingMemoryLineOutput] = Field(default_factory=list)
+    open_risks: list[WorkingMemoryLineOutput] = Field(default_factory=list)
+    follow_up_queries: list[WorkingMemoryLineOutput] = Field(default_factory=list)
 
 
 def _candidate_for_prompt(record: dict[str, Any]) -> dict[str, Any]:
@@ -67,6 +80,64 @@ def _candidate_for_prompt(record: dict[str, Any]) -> dict[str, Any]:
         "outcomes": record.get("outcomes"),
         "updated_at": record.get("updated_at"),
     }
+
+
+def _candidate_profile(records: list[dict[str, Any]]) -> dict[str, Any]:
+    """Return compact metadata that frames what the records can support."""
+    kind_counts: dict[str, int] = {}
+    record_ids_by_kind: dict[str, list[str]] = {}
+    newest_updated_at = ""
+    newest_episode_updated_at = ""
+    for record in records:
+        kind = str(record.get("kind") or "unknown")
+        kind_counts[kind] = kind_counts.get(kind, 0) + 1
+        record_id = str(record.get("record_id") or "")
+        if record_id:
+            record_ids_by_kind.setdefault(kind, []).append(record_id)
+        updated_at = str(record.get("updated_at") or "")
+        newest_updated_at = max(newest_updated_at, updated_at)
+        if kind == "episode":
+            newest_episode_updated_at = max(newest_episode_updated_at, updated_at)
+    episode_count = int(kind_counts.get("episode") or 0)
+    episode_record_ids = record_ids_by_kind.get("episode", [])
+    return {
+        "candidate_count": len(records),
+        "kind_counts": kind_counts,
+        "record_ids_by_kind": record_ids_by_kind,
+        "newest_updated_at": newest_updated_at or None,
+        "newest_episode_updated_at": newest_episode_updated_at or None,
+        "has_recent_flow_evidence": episode_count > 0,
+        "current_handoff_evidence_record_ids": episode_record_ids,
+        "guidance": (
+            "Only populate current_handoff when cited records describe recent flow, "
+            "current work, open loops, or next commands. Leave open_risks empty unless "
+            "cited record text explicitly supports an unresolved risk, blocker, or "
+            "requested follow-up. Treat all test/build results as historical persisted "
+            "evidence and tell agents to rerun relevant checks after edits."
+        ),
+    }
+
+
+def _memory_lines(lines: list[WorkingMemoryLineOutput]) -> tuple[MemoryLine, ...]:
+    """Convert model line objects into draft memory lines."""
+    return tuple(
+        MemoryLine(text=line.text, record_ids=tuple(line.record_ids))
+        for line in lines
+    )
+
+
+def _draft_from_output(output: WorkingMemoryOutput) -> WorkingMemoryDraft:
+    """Build a fixed-section WorkingMemoryDraft from model output."""
+    return WorkingMemoryDraft(
+        summary=_memory_lines(output.summary),
+        start_here=_memory_lines(output.start_here),
+        current_handoff=_memory_lines(output.current_handoff),
+        decisions=_memory_lines(output.decisions),
+        constraints_preferences=_memory_lines(output.constraints_preferences),
+        project_facts=_memory_lines(output.project_facts),
+        open_risks=_memory_lines(output.open_risks),
+        follow_up_queries=_memory_lines(output.follow_up_queries),
+    )
 
 
 def build_working_memory_agent(model: Model) -> Agent[None, WorkingMemoryOutput]:
@@ -91,9 +162,26 @@ def run_working_memory_synthesis(
     """Run LLM synthesis over bounded candidate records."""
     agent = build_working_memory_agent(model)
     compact_candidates = [_candidate_for_prompt(record) for record in candidates]
+    profile = _candidate_profile(candidates)
     prompt = (
-        "Create a compact Working Memory from these candidate records.\n"
-        "Return only cited lines using exact record_id values.\n\n"
+        "Create a compact Working Memory from these candidate records for a coding "
+        "agent starting a new session.\n"
+        "Return the fixed fields summary, start_here, current_handoff, decisions, "
+        "constraints_preferences, project_facts, open_risks, and follow_up_queries. "
+        "Each field must be a list of {text, record_ids} objects.\n"
+        "Return only cited lines using exact record_id values in record_ids.\n"
+        "Do not place record IDs or citation syntax inside the line text.\n"
+        "Prefer fields that answer: what matters now, what decisions are fixed, "
+        "what constraints/preferences must be followed, what project facts prevent "
+        "mistakes, and what to inspect next. Do not turn established decisions into "
+        "todos or claim implementation status that is not present in the records.\n"
+        "Keep current_handoff empty unless a cited record supports current or recent "
+        "handoff evidence. Keep open_risks empty unless a cited record supports a "
+        "real unresolved risk, blocker, or requested follow-up. If mentioning test, "
+        "build, lint, typecheck, CI, or verification results, write them as "
+        "historical persisted evidence with the wording \"Persisted record says ...\" "
+        "and \"rerun relevant tests after edits.\"\n\n"
+        f"Candidate profile JSON:\n{json.dumps(profile, ensure_ascii=True)}\n\n"
         f"Candidate records JSON:\n{json.dumps(compact_candidates, ensure_ascii=True)}"
     )
     with mlflow_span(
@@ -107,22 +195,7 @@ def run_working_memory_synthesis(
             usage_limits=UsageLimits(request_limit=max(1, int(request_limit))),
             event_stream_handler=handle_mlflow_event_stream,
         )
-    draft = WorkingMemoryDraft(
-        summary=tuple(
-            MemoryLine(text=line.text, record_ids=tuple(line.record_ids))
-            for line in result.output.summary
-        ),
-        sections=tuple(
-            MemorySection(
-                title=section.title,
-                lines=tuple(
-                    MemoryLine(text=line.text, record_ids=tuple(line.record_ids))
-                    for line in section.lines
-                ),
-            )
-            for section in result.output.sections
-        ),
-    )
+    draft = _draft_from_output(result.output)
     if return_messages:
         return draft, list(result.all_messages())
     return draft

--- a/src/lerim/agents/working_memory.py
+++ b/src/lerim/agents/working_memory.py
@@ -1,0 +1,128 @@
+"""LLM synthesis adapter for generated Working Memory artifacts."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from pydantic import BaseModel, Field
+from pydantic_ai import Agent
+from pydantic_ai.models import Model
+from pydantic_ai.usage import UsageLimits
+
+from lerim.agents.mlflow_observability import handle_mlflow_event_stream, mlflow_span
+from lerim.agents.model_settings import LOW_VARIANCE_AGENT_MODEL_SETTINGS
+from lerim.working_memory import MemoryLine, MemorySection, WorkingMemoryDraft
+
+
+WORKING_MEMORY_SYSTEM_PROMPT = """\
+<role>
+You write Lerim Working Memory for coding agents.
+</role>
+
+<rules>
+- Use only the candidate records supplied in the prompt.
+- Prefer durable records: decision, preference, constraint, fact, reference.
+- Use episode records only for recent flow context or when no durable record covers the topic.
+- Keep the result compact enough for a roughly 50-line markdown file.
+- Every line must include at least one exact record_id from the supplied candidates.
+- Do not quote long evidence. Compress and preserve the practical instruction or fact.
+- Do not invent current repository state beyond the stored records.
+</rules>
+"""
+
+
+class WorkingMemoryLineOutput(BaseModel):
+    """One cited line in the generated Working Memory draft."""
+
+    text: str = Field(description="Compact memory statement without citations")
+    record_ids: list[str] = Field(description="Exact source record IDs")
+
+
+class WorkingMemorySectionOutput(BaseModel):
+    """One named section in the generated Working Memory draft."""
+
+    title: str
+    lines: list[WorkingMemoryLineOutput]
+
+
+class WorkingMemoryOutput(BaseModel):
+    """Structured output returned by the Working Memory synthesis agent."""
+
+    summary: list[WorkingMemoryLineOutput]
+    sections: list[WorkingMemorySectionOutput]
+
+
+def _candidate_for_prompt(record: dict[str, Any]) -> dict[str, Any]:
+    """Return the compact candidate fields shown to the model."""
+    return {
+        "record_id": record.get("record_id"),
+        "kind": record.get("kind"),
+        "title": record.get("title"),
+        "body": record.get("body"),
+        "decision": record.get("decision"),
+        "why": record.get("why"),
+        "user_intent": record.get("user_intent"),
+        "what_happened": record.get("what_happened"),
+        "outcomes": record.get("outcomes"),
+        "updated_at": record.get("updated_at"),
+    }
+
+
+def build_working_memory_agent(model: Model) -> Agent[None, WorkingMemoryOutput]:
+    """Build the Working Memory synthesis agent."""
+    return Agent(
+        model,
+        output_type=WorkingMemoryOutput,
+        system_prompt=WORKING_MEMORY_SYSTEM_PROMPT,
+        model_settings=LOW_VARIANCE_AGENT_MODEL_SETTINGS,
+        retries=3,
+        output_retries=2,
+    )
+
+
+def run_working_memory_synthesis(
+    *,
+    model: Model,
+    candidates: list[dict[str, Any]],
+    request_limit: int = 8,
+    return_messages: bool = False,
+) -> WorkingMemoryDraft | tuple[WorkingMemoryDraft, list[Any]]:
+    """Run LLM synthesis over bounded candidate records."""
+    agent = build_working_memory_agent(model)
+    compact_candidates = [_candidate_for_prompt(record) for record in candidates]
+    prompt = (
+        "Create a compact Working Memory from these candidate records.\n"
+        "Return only cited lines using exact record_id values.\n\n"
+        f"Candidate records JSON:\n{json.dumps(compact_candidates, ensure_ascii=True)}"
+    )
+    with mlflow_span(
+        "lerim.agent.working_memory",
+        span_type="AGENT",
+        attributes={"lerim.agent_name": "working_memory"},
+        inputs={"candidate_count": len(compact_candidates)},
+    ):
+        result = agent.run_sync(
+            prompt,
+            usage_limits=UsageLimits(request_limit=max(1, int(request_limit))),
+            event_stream_handler=handle_mlflow_event_stream,
+        )
+    draft = WorkingMemoryDraft(
+        summary=tuple(
+            MemoryLine(text=line.text, record_ids=tuple(line.record_ids))
+            for line in result.output.summary
+        ),
+        sections=tuple(
+            MemorySection(
+                title=section.title,
+                lines=tuple(
+                    MemoryLine(text=line.text, record_ids=tuple(line.record_ids))
+                    for line in section.lines
+                ),
+            )
+            for section in result.output.sections
+        ),
+    )
+    if return_messages:
+        return draft, list(result.all_messages())
+    return draft

--- a/src/lerim/server/api.py
+++ b/src/lerim/server/api.py
@@ -32,7 +32,6 @@ from lerim.server.daemon import (
     LockBusyError,
     ServiceLock,
     WRITER_LOCK_NAME,
-    lock_path,
     resolve_window_bounds,
     run_maintain_once,
     run_sync_once,
@@ -543,7 +542,10 @@ def api_memory_reset(
     kept = ["config", "env", "platforms", "projects"]
     lock: ServiceLock | None = None
     if not dry_run:
-        lock = ServiceLock(lock_path(WRITER_LOCK_NAME), stale_seconds=60)
+        lock = ServiceLock(
+            config.global_data_dir / "index" / WRITER_LOCK_NAME,
+            stale_seconds=60,
+        )
         try:
             lock.acquire("memory-reset", "lerim memory reset")
         except LockBusyError as exc:

--- a/src/lerim/server/cli.py
+++ b/src/lerim/server/cli.py
@@ -315,7 +315,28 @@ def _cmd_working_memory(args: argparse.Namespace) -> int:
 
     if action == "show":
         if paths.current_file.is_file():
-            _emit(paths.current_file.read_text(encoding="utf-8").rstrip("\n"))
+            store = ContextStore(config.context_db_path)
+            status = status_to_dict(
+                working_memory_status(config=config, store=store, project=project)
+            )
+            preface = [
+                "Working Memory Live Status:",
+                f"- availability: {status['availability']}",
+                f"- generated_at: {status['generated_at']}",
+                f"- age: {status['age']}",
+                (
+                    "- db_records_changed_since_generation: "
+                    f"{status['records_changed_since_generation']}"
+                ),
+                f"- suggested_action: {working_memory_show_action(status)}",
+                "",
+                "---",
+                "",
+            ]
+            _emit(
+                "\n".join(preface)
+                + paths.current_file.read_text(encoding="utf-8").rstrip("\n")
+            )
             return 0
         message = (
             f"No Working Memory generated yet for project `{project.name}`.\n"
@@ -376,6 +397,15 @@ def _cmd_working_memory(args: argparse.Namespace) -> int:
 
     _emit(f"Unknown working-memory action: {action}", file=sys.stderr)
     return 2
+
+
+def working_memory_show_action(status: dict[str, Any]) -> str:
+    """Return a contextual action for the already-running show command."""
+    if status.get("availability") == "stale":
+        return "Refresh if newest persisted DB context matters."
+    if status.get("availability") == "available":
+        return "Continue with this startup context; inspect sources or query deeper if needed."
+    return str(status.get("suggested_action") or "Run `lerim working-memory status`.")
 
 
 def _cmd_dashboard(args: argparse.Namespace) -> int:

--- a/src/lerim/server/cli.py
+++ b/src/lerim/server/cli.py
@@ -47,6 +47,8 @@ from lerim.server.docker_runtime import (
 from lerim.server.daemon import (
     run_maintain_once,
     run_sync_once,
+    run_working_memory_daily,
+    run_working_memory_for_project,
     resolve_window_bounds,
 )
 from lerim.server.cli_api_client import (
@@ -59,7 +61,14 @@ from lerim.config.logging import configure_logging
 from lerim.cloud.auth import cmd_auth, cmd_auth_logout, cmd_auth_status
 from lerim.config.settings import get_config, get_user_config_path, get_user_env_path
 from lerim.config.tracing import configure_tracing
+from lerim.context import ContextStore
 from lerim.context.query_spec import QUERY_ENTITIES, QUERY_MODES, QUERY_ORDER_FIELDS
+from lerim.working_memory import (
+    resolve_working_memory_project,
+    status_to_dict,
+    working_memory_paths,
+    working_memory_status,
+)
 
 
 def _emit(message: object = "", *, file: Any | None = None) -> None:
@@ -261,6 +270,112 @@ def _cmd_maintain(args: argparse.Namespace) -> int:
             if advice:
                 _emit(f"  {advice}")
     return 0
+
+
+def _working_memory_project_from_args(args: argparse.Namespace) -> Any:
+    """Resolve the current Working Memory project for CLI commands."""
+    config = get_config()
+    return resolve_working_memory_project(
+        config=config,
+        project=getattr(args, "project", None),
+        cwd=Path.cwd(),
+    )
+
+
+def _cmd_working_memory(args: argparse.Namespace) -> int:
+    """Handle local Working Memory commands."""
+    action = getattr(args, "working_memory_action", None)
+    if not action:
+        _emit("Usage: lerim working-memory {show,status,path,refresh}", file=sys.stderr)
+        return 2
+    try:
+        project = _working_memory_project_from_args(args)
+    except ValueError as exc:
+        if args.json:
+            _emit(json.dumps({"error": True, "message": str(exc)}, indent=2))
+        else:
+            _emit(str(exc), file=sys.stderr)
+        return 1
+
+    config = get_config()
+    paths = working_memory_paths(config, project.identity.project_id)
+
+    if action == "path":
+        payload = {
+            "project": project.name,
+            "project_id": project.identity.project_id,
+            "current_file": str(paths.current_file),
+            "exists": paths.current_file.is_file(),
+        }
+        if args.json:
+            _emit(json.dumps(payload, indent=2, ensure_ascii=True))
+        else:
+            _emit(paths.current_file)
+        return 0
+
+    if action == "show":
+        if paths.current_file.is_file():
+            _emit(paths.current_file.read_text(encoding="utf-8").rstrip("\n"))
+            return 0
+        message = (
+            f"No Working Memory generated yet for project `{project.name}`.\n"
+            "Run: lerim working-memory refresh"
+        )
+        if args.json:
+            _emit(
+                json.dumps(
+                    {
+                        "error": True,
+                        "project": project.name,
+                        "project_id": project.identity.project_id,
+                        "current_file": str(paths.current_file),
+                        "message": message,
+                    },
+                    indent=2,
+                    ensure_ascii=True,
+                )
+            )
+        else:
+            _emit(message)
+        return 1
+
+    if action == "status":
+        store = ContextStore(config.context_db_path)
+        status = working_memory_status(config=config, store=store, project=project)
+        payload = status_to_dict(status)
+        if args.json:
+            _emit(json.dumps(payload, indent=2, ensure_ascii=True))
+        else:
+            _emit("Working Memory:")
+            for key, value in payload.items():
+                _emit(f"- {key}: {value}")
+        return 0
+
+    if action == "refresh":
+        result = run_working_memory_for_project(
+            project_name=project.name,
+            project_path=project.identity.repo_path,
+            trigger="manual",
+            force=bool(getattr(args, "force", False)),
+        )
+        if args.json:
+            _emit(json.dumps(result, indent=2, ensure_ascii=True))
+        else:
+            if result.get("status") == "skipped":
+                _emit(f"Working Memory skipped for {project.name}: {result.get('skip_reason')}")
+            elif result.get("status") == "failed":
+                _emit(f"Working Memory failed for {project.name}: {result.get('error')}", file=sys.stderr)
+                return 1
+            else:
+                _emit(f"Working Memory generated for {project.name}.")
+            if result.get("current_file"):
+                _emit(f"- current_file: {result.get('current_file')}")
+            if result.get("run_folder"):
+                _emit(f"- run_folder: {result.get('run_folder')}")
+        return 0
+
+    _emit(f"Unknown working-memory action: {action}", file=sys.stderr)
+    return 2
 
 
 def _cmd_dashboard(args: argparse.Namespace) -> int:
@@ -1211,6 +1326,7 @@ def _cmd_serve(args: argparse.Namespace) -> int:
 
         sync_interval = max(config.sync_interval_minutes * 60, 30)
         maintain_interval = max(config.maintain_interval_minutes * 60, 30)
+        working_memory_interval = 24 * 60 * 60
 
         # Initialise to (now - interval) so both trigger on the first
         # iteration regardless of the monotonic clock epoch.  In Docker
@@ -1220,6 +1336,7 @@ def _cmd_serve(args: argparse.Namespace) -> int:
         _now_init = time.monotonic()
         last_sync = _now_init - sync_interval
         last_maintain = _now_init - maintain_interval
+        last_working_memory = _now_init - working_memory_interval
         last_degraded_log_at = 0.0
         degraded_log_interval_seconds = 300.0
 
@@ -1281,6 +1398,15 @@ def _cmd_serve(args: argparse.Namespace) -> int:
                     logger.warning("daemon maintain error: {}", exc)
                 last_maintain = time.monotonic()
 
+            if now - last_working_memory >= working_memory_interval:
+                try:
+                    with ollama_lifecycle(config):
+                        details = run_working_memory_daily(trigger="daily")
+                    logger.info("daemon working-memory done — {}", details)
+                except Exception as exc:
+                    logger.warning("daemon working-memory error: {}", exc)
+                last_working_memory = time.monotonic()
+
             # Ship to cloud (best-effort)
             if config.cloud_token:
                 try:
@@ -1308,7 +1434,11 @@ def _cmd_serve(args: argparse.Namespace) -> int:
 
             next_sync = last_sync + sync_interval
             next_maintain = last_maintain + maintain_interval
-            sleep_for = max(1.0, min(next_sync, next_maintain) - time.monotonic())
+            next_working_memory = last_working_memory + working_memory_interval
+            sleep_for = max(
+                1.0,
+                min(next_sync, next_maintain, next_working_memory) - time.monotonic(),
+            )
             stop_event.wait(sleep_for)
 
     daemon_thread = threading.Thread(
@@ -1538,6 +1668,44 @@ def build_parser() -> argparse.ArgumentParser:
     )
     _add_dry_run_flag(maintain)
     maintain.set_defaults(func=_cmd_maintain)
+
+    # ── working-memory ───────────────────────────────────────────────
+    working_memory = sub.add_parser(
+        "working-memory",
+        formatter_class=_F,
+        help="Read or refresh generated project Working Memory",
+        description=(
+            "Generated markdown startup context for coding agents.\n\n"
+            "Examples:\n"
+            "  lerim working-memory show\n"
+            "  lerim working-memory status\n"
+            "  lerim working-memory refresh --force"
+        ),
+    )
+    working_memory_sub = working_memory.add_subparsers(
+        dest="working_memory_action"
+    )
+    for action_name in ("show", "status", "path"):
+        action = working_memory_sub.add_parser(
+            action_name,
+            formatter_class=_F,
+            help=f"{action_name} Working Memory",
+        )
+        action.add_argument(
+            "--project",
+            help="Registered project name or path. Defaults to cwd project.",
+        )
+    wm_refresh = working_memory_sub.add_parser(
+        "refresh",
+        formatter_class=_F,
+        help="Generate Working Memory for the resolved project",
+    )
+    wm_refresh.add_argument(
+        "--project",
+        help="Registered project name or path. Defaults to cwd project.",
+    )
+    _add_force_flag(wm_refresh)
+    working_memory.set_defaults(func=_cmd_working_memory)
 
     # ── dashboard ────────────────────────────────────────────────────
     dashboard = sub.add_parser(
@@ -1930,6 +2098,14 @@ def main(argv: list[str] | None = None) -> int:
         return 0
 
     if args.command == "memory" and not getattr(args, "memory_action", None):
+        parser.parse_args([args.command, "--help"])
+        return 0
+
+    if args.command == "working-memory" and not getattr(
+        args,
+        "working_memory_action",
+        None,
+    ):
         parser.parse_args([args.command, "--help"])
         return 0
 

--- a/src/lerim/server/daemon.py
+++ b/src/lerim/server/daemon.py
@@ -612,6 +612,7 @@ def run_working_memory_for_project(
             repo_root=project_path,
             project_name=project_name,
             force=force,
+            trigger=trigger,
         )
         status = "skipped" if result.get("status") == "skipped" else "completed"
         _record_service_event(

--- a/src/lerim/server/daemon.py
+++ b/src/lerim/server/daemon.py
@@ -588,6 +588,83 @@ def _aggregate_maintain_totals(
     return totals
 
 
+def _record_count_delta(payload: dict[str, Any]) -> int:
+    """Return total context record changes from a runtime payload."""
+    return (
+        int(payload.get("records_created") or 0)
+        + int(payload.get("records_updated") or 0)
+        + int(payload.get("records_archived") or 0)
+    )
+
+
+def run_working_memory_for_project(
+    *,
+    project_name: str,
+    project_path: Path,
+    trigger: str,
+    force: bool = False,
+) -> dict[str, Any]:
+    """Run one Working Memory refresh and record a service-run row."""
+    started = _now_iso()
+    try:
+        agent = LerimRuntime(default_cwd=str(project_path))
+        result = agent.working_memory(
+            repo_root=project_path,
+            project_name=project_name,
+            force=force,
+        )
+        status = "skipped" if result.get("status") == "skipped" else "completed"
+        _record_service_event(
+            record_service_run,
+            job_type="working-memory",
+            status=status,
+            started_at=started,
+            trigger=trigger,
+            details=result,
+        )
+        return result
+    except Exception as exc:
+        details = {
+            "project": project_name,
+            "repo_path": str(project_path),
+            "error": str(exc),
+        }
+        _record_service_event(
+            record_service_run,
+            job_type="working-memory",
+            status="failed",
+            started_at=started,
+            trigger=trigger,
+            details=details,
+        )
+        return {"status": "failed", **details}
+
+
+def run_working_memory_daily(*, trigger: str = "daemon") -> dict[str, Any]:
+    """Refresh Working Memory for all registered projects, skipping unchanged ones."""
+    reload_config()
+    config = get_config()
+    projects = config.projects or {}
+    results: dict[str, dict[str, Any]] = {}
+    for project_name, project_path_str in projects.items():
+        project_path = Path(project_path_str).expanduser().resolve()
+        results[project_name] = run_working_memory_for_project(
+            project_name=project_name,
+            project_path=project_path,
+            trigger=trigger,
+            force=False,
+        )
+    generated = sum(1 for item in results.values() if item.get("status") == "generated")
+    skipped = sum(1 for item in results.values() if item.get("status") == "skipped")
+    failed = sum(1 for item in results.values() if item.get("status") == "failed")
+    return {
+        "projects": results,
+        "generated": generated,
+        "skipped": skipped,
+        "failed": failed,
+    }
+
+
 def _process_one_job(job: dict[str, Any]) -> dict[str, Any]:
     """Process a single claimed session job. Thread-safe (own agent instance)."""
     started_monotonic = time.monotonic()
@@ -1154,6 +1231,14 @@ def run_maintain_once(
                     "consolidated": int(raw_counts.get("consolidated") or 0),
                     "unchanged": int(raw_counts.get("unchanged") or 0),
                 }
+                if _record_count_delta(metric_row) > 0:
+                    wm_result = run_working_memory_for_project(
+                        project_name=project_name,
+                        project_path=project_path,
+                        trigger="maintain",
+                        force=False,
+                    )
+                    results[project_name]["working_memory"] = wm_result
             except Exception as exc:
                 failed_projects.append(project_name)
                 results[project_name] = {"error": str(exc)}

--- a/src/lerim/server/runtime.py
+++ b/src/lerim/server/runtime.py
@@ -841,6 +841,7 @@ class LerimRuntime:
         *,
         project_name: str | None = None,
         force: bool = False,
+        trigger: str = "manual",
     ) -> dict[str, Any]:
         """Generate or skip one project's derived Working Memory artifact."""
         resolved_repo_root = (
@@ -877,6 +878,7 @@ class LerimRuntime:
                 "status": "skipped",
                 "project": display_name,
                 "project_id": project_identity.project_id,
+                "trigger": trigger,
                 "generated_at": previous_generated_at or None,
                 "context_db_path": str(self.config.context_db_path),
                 "workspace_root": str(resolved_workspace_root),
@@ -960,9 +962,15 @@ class LerimRuntime:
             markdown = render_working_memory_markdown(
                 project=project,
                 generated_at=generated_at,
+                previous_generated_at=previous_generated_at or None,
+                generation_trigger=trigger,
+                records_considered=len(candidates),
                 records_included=len(record_ids),
-                changed_since_generation=0,
+                db_records_changed_since_previous=changed_since_previous,
                 draft=draft,
+                candidate_records=candidates,
+                current_file=current_paths.current_file,
+                run_folder=run_folder,
             )
             _write_text_with_newline(artifact_paths["working_memory"], markdown)
             response_text = (
@@ -984,6 +992,7 @@ class LerimRuntime:
                 records_included=len(record_ids),
                 included_record_ids_value=record_ids,
                 changed_records_since_previous=changed_since_previous,
+                trigger=trigger,
                 current_file=current_paths.current_file,
                 run_folder=run_folder,
             )
@@ -1015,6 +1024,7 @@ class LerimRuntime:
                 "status": "generated",
                 "project": display_name,
                 "project_id": project_identity.project_id,
+                "trigger": trigger,
                 "generated_at": generated_at,
                 "context_db_path": str(self.config.context_db_path),
                 "workspace_root": str(resolved_workspace_root),

--- a/src/lerim/server/runtime.py
+++ b/src/lerim/server/runtime.py
@@ -15,13 +15,32 @@ from pathlib import Path
 from typing import Any, Callable, Iterator
 
 from lerim.agents.ask import run_ask
-from lerim.agents.contracts import MaintainResultContract, SyncResultContract
+from lerim.agents.contracts import (
+    MaintainResultContract,
+    SyncResultContract,
+    WorkingMemoryResultContract,
+)
 from lerim.agents.extract import ExtractionResult, run_extraction
 from lerim.agents.maintain import run_maintain
 from lerim.agents.mlflow_observability import finish_mlflow_run, lerim_mlflow_run
+from lerim.agents.working_memory import run_working_memory_synthesis
 from lerim.config.providers import build_pydantic_model
 from lerim.config.settings import Config, get_config
 from lerim.context import resolve_project_identity
+from lerim.working_memory import (
+    WORKING_MEMORY_FILENAME,
+    WORKING_MEMORY_OPERATION,
+    build_manifest,
+    count_changed_records_since,
+    empty_working_memory_draft,
+    included_record_ids,
+    load_candidate_records,
+    render_working_memory_markdown,
+    utc_now_iso,
+    validate_draft,
+    WorkingMemoryProject,
+    working_memory_paths,
+)
 from pydantic_ai.messages import ModelMessage, ModelMessagesTypeAdapter
 
 logger = logging.getLogger("lerim.runtime")
@@ -804,6 +823,214 @@ class LerimRuntime:
                 return MaintainResultContract.model_validate(payload).model_dump(
                     mode="json"
                 )
+        except Exception as exc:
+            _mark_run_failed(
+                artifact_paths=artifact_paths,
+                manifest=manifest,
+                exc=exc,
+            )
+            raise
+
+    # ------------------------------------------------------------------
+    # Working Memory flow
+    # ------------------------------------------------------------------
+
+    def working_memory(
+        self,
+        repo_root: str | Path | None = None,
+        *,
+        project_name: str | None = None,
+        force: bool = False,
+    ) -> dict[str, Any]:
+        """Generate or skip one project's derived Working Memory artifact."""
+        resolved_repo_root = (
+            Path(repo_root).expanduser().resolve()
+            if repo_root
+            else Path(self._default_cwd or Path.cwd()).expanduser().resolve()
+        )
+        project_identity = resolve_project_identity(resolved_repo_root)
+        display_name = project_name or project_identity.project_slug
+        resolved_workspace_root = _resolve_runtime_roots(config=self.config)
+        store = _store_for_config(self.config)
+        store.register_project(project_identity)
+        current_paths = working_memory_paths(
+            self.config,
+            project_identity.project_id,
+        )
+        current_manifest: dict[str, Any] = {}
+        if current_paths.current_manifest.is_file():
+            try:
+                current_manifest = json.loads(
+                    current_paths.current_manifest.read_text(encoding="utf-8")
+                )
+            except (OSError, json.JSONDecodeError):
+                current_manifest = {}
+        previous_generated_at = str(current_manifest.get("generated_at") or "").strip()
+        changed_since_previous = count_changed_records_since(
+            store,
+            project_id=project_identity.project_id,
+            since=previous_generated_at or None,
+        )
+        current_exists = current_paths.current_file.is_file()
+        if current_exists and not force and changed_since_previous == 0:
+            payload = {
+                "status": "skipped",
+                "project": display_name,
+                "project_id": project_identity.project_id,
+                "generated_at": previous_generated_at or None,
+                "context_db_path": str(self.config.context_db_path),
+                "workspace_root": str(resolved_workspace_root),
+                "run_folder": None,
+                "current_file": str(current_paths.current_file),
+                "current_manifest": str(current_paths.current_manifest),
+                "records_considered": 0,
+                "records_included": int(current_manifest.get("records_included") or 0),
+                "records_changed_since_previous": 0,
+                "included_record_ids": list(
+                    current_manifest.get("included_record_ids") or []
+                ),
+                "skip_reason": "no_records_changed_since_previous_generation",
+                "cost_usd": 0.0,
+            }
+            return WorkingMemoryResultContract.model_validate(payload).model_dump(
+                mode="json"
+            )
+
+        run_id, run_folder = _new_run_folder(
+            resolved_workspace_root,
+            WORKING_MEMORY_OPERATION,
+        )
+        artifact_paths = _build_artifact_paths(run_folder, include_session_log=False)
+        artifact_paths["working_memory"] = run_folder / WORKING_MEMORY_FILENAME
+        artifact_paths["subagents_log"].write_text("", encoding="utf-8")
+        started_at = utc_now_iso()
+        manifest = {
+            "run_id": run_id,
+            "operation": WORKING_MEMORY_OPERATION,
+            "status": "running",
+            "started_at": started_at,
+            "mlflow_client_request_id": run_id,
+            "project_id": project_identity.project_id,
+            "project": display_name,
+            "repo_path": str(project_identity.repo_path),
+            "workspace_root": str(resolved_workspace_root),
+            "run_folder": str(run_folder),
+            "artifacts": {key: str(path) for key, path in artifact_paths.items()},
+        }
+        _write_json_artifact(artifact_paths["manifest"], manifest)
+        _append_jsonl_artifact(
+            artifact_paths["events"],
+            {"ts": started_at, "event": "started", "run_id": run_id},
+        )
+
+        try:
+            candidates = load_candidate_records(
+                store,
+                project_id=project_identity.project_id,
+            )
+            messages: list[ModelMessage] = []
+            if candidates:
+                def _primary_builder() -> Any:
+                    return build_pydantic_model("agent", config=self.config)
+
+                def _call(model: Any) -> tuple[Any, list[ModelMessage]]:
+                    return run_working_memory_synthesis(
+                        model=model,
+                        candidates=candidates,
+                        return_messages=True,
+                    )
+
+                draft, messages = self._run_with_fallback(
+                    flow=WORKING_MEMORY_OPERATION,
+                    callable_fn=_call,
+                    model_builders=[_primary_builder],
+                )
+                if not draft.summary and not draft.sections:
+                    raise ValueError("working_memory_synthesis_empty")
+            else:
+                draft = empty_working_memory_draft()
+            allowed_ids = {str(record.get("record_id") or "") for record in candidates}
+            validate_draft(draft, allowed_record_ids=allowed_ids)
+            record_ids = included_record_ids(draft)
+            generated_at = utc_now_iso()
+            project = WorkingMemoryProject(
+                name=display_name,
+                identity=project_identity,
+            )
+            markdown = render_working_memory_markdown(
+                project=project,
+                generated_at=generated_at,
+                records_included=len(record_ids),
+                changed_since_generation=0,
+                draft=draft,
+            )
+            _write_text_with_newline(artifact_paths["working_memory"], markdown)
+            response_text = (
+                f"Working Memory generated with {len(record_ids)} cited record(s)."
+            )
+            _write_text_with_newline(artifact_paths["agent_log"], response_text)
+            try:
+                _write_agent_trace(artifact_paths["agent_trace"], messages)
+            except Exception as exc:
+                logger.warning(f"[working-memory] Failed to write agent trace: {exc}")
+                artifact_paths["agent_trace"].write_text("[]", encoding="utf-8")
+
+            manifest = build_manifest(
+                run_id=run_id,
+                status="succeeded",
+                generated_at=generated_at,
+                project=project,
+                records_considered=len(candidates),
+                records_included=len(record_ids),
+                included_record_ids_value=record_ids,
+                changed_records_since_previous=changed_since_previous,
+                current_file=current_paths.current_file,
+                run_folder=run_folder,
+            )
+            manifest["completed_at"] = utc_now_iso()
+            manifest["workspace_root"] = str(resolved_workspace_root)
+            manifest["artifacts"] = {
+                key: str(path) for key, path in artifact_paths.items()
+            }
+            _write_json_artifact(artifact_paths["manifest"], manifest)
+            _append_jsonl_artifact(
+                artifact_paths["events"],
+                {
+                    "ts": manifest["completed_at"],
+                    "event": "succeeded",
+                    "run_id": run_id,
+                    "records_considered": len(candidates),
+                    "records_included": len(record_ids),
+                    "records_changed_since_previous": changed_since_previous,
+                },
+            )
+            from lerim.working_memory import write_current_artifacts
+
+            write_current_artifacts(
+                paths=current_paths,
+                run_markdown=artifact_paths["working_memory"],
+                run_manifest=artifact_paths["manifest"],
+            )
+            payload = {
+                "status": "generated",
+                "project": display_name,
+                "project_id": project_identity.project_id,
+                "generated_at": generated_at,
+                "context_db_path": str(self.config.context_db_path),
+                "workspace_root": str(resolved_workspace_root),
+                "run_folder": str(run_folder),
+                "current_file": str(current_paths.current_file),
+                "current_manifest": str(current_paths.current_manifest),
+                "records_considered": len(candidates),
+                "records_included": len(record_ids),
+                "records_changed_since_previous": changed_since_previous,
+                "included_record_ids": list(record_ids),
+                "skip_reason": None,
+                "cost_usd": 0.0,
+            }
+            return WorkingMemoryResultContract.model_validate(payload).model_dump(
+                mode="json"
+            )
         except Exception as exc:
             _mark_run_failed(
                 artifact_paths=artifact_paths,

--- a/src/lerim/skills/SKILL.md
+++ b/src/lerim/skills/SKILL.md
@@ -46,7 +46,8 @@ lerim status --json
 
 Working Memory is the startup path. It is generated ahead of time by the daemon
 or by `lerim working-memory refresh`, so `show`, `status`, and `path` should be
-fast local reads.
+fast local reads. `show` prepends live DB freshness before printing the static
+markdown snapshot.
 
 ```mermaid
 flowchart TD
@@ -64,10 +65,14 @@ flowchart TD
 ## Working rules
 
 - Working Memory is a generated markdown view of SQLite records, not durable state.
-- Read the freshness block. If it reports changed records and newest context matters, suggest `lerim working-memory refresh`.
-- Use `lerim working-memory status` to see dynamic age, record-change count, current path, latest run, and suggested action.
+- Read the live freshness block. If it reports changed DB records and newest context matters, suggest `lerim working-memory refresh`.
+- Use `lerim working-memory status` to see dynamic age, DB record-change count, current path, latest run, and suggested action.
 - Use `lerim working-memory path` when another tool needs the stable Markdown path.
 - Do not hardcode project IDs. Run commands from inside the repo or pass `--project <name-or-path>`.
+- Treat test/build results inside Working Memory as historical persisted evidence; rerun relevant checks after edits.
+- Expect a fixed section order: Summary, Start Here, Current Handoff, Decisions, Constraints & Preferences, Project Facts, Open Risks / Review Queue, Follow-up Queries, Sources.
+- Treat Start Here as deterministic Lerim guidance, not model synthesis.
+- Trust Current Handoff only when it cites recent episode evidence; otherwise use the current chat, git state, and tests for live implementation status.
 - Prefer `query` over `ask` when the question is exact.
 - Prefer `ask` over manual browsing when the question needs synthesis across records.
 - Treat Lerim as the context layer, not as a place to manually edit durable state during normal coding work.

--- a/src/lerim/skills/SKILL.md
+++ b/src/lerim/skills/SKILL.md
@@ -9,6 +9,7 @@ Use this skill when you need project context before or during coding work.
 
 Lerim stores durable context from past agent sessions and exposes it through a small CLI/API surface. The important distinction is:
 
+- `lerim working-memory show` for instant precomputed startup context
 - `lerim query` for exact deterministic retrieval
 - `lerim ask` for retrieval plus synthesis
 - `lerim status` for runtime health, project counts, and queue state
@@ -24,13 +25,16 @@ Lerim stores durable context from past agent sessions and exposes it through a s
 
 Start with the smallest tool that answers the question:
 
-1. Use `lerim query` for counts, latest rows, date windows, and exact inspection.
-2. Use `lerim ask` when you need a synthesized explanation or semantic retrieval.
-3. Use `lerim status` or `lerim queue` when the question is operational rather than semantic.
+1. Use `lerim working-memory show` at startup for fast project context.
+2. Use `lerim query` for counts, latest rows, date windows, and exact inspection.
+3. Use `lerim ask` when you need a synthesized explanation or semantic retrieval.
+4. Use `lerim status` or `lerim queue` when the question is operational rather than semantic.
 
 Examples:
 
 ```bash
+lerim working-memory show
+lerim working-memory status
 lerim query records count --kind decision
 lerim query records list --kind constraint --limit 10
 lerim ask "What do we already know about the auth flow?"
@@ -38,8 +42,32 @@ lerim ask "What changed recently about storage and why?"
 lerim status --json
 ```
 
+## Working Memory flow
+
+Working Memory is the startup path. It is generated ahead of time by the daemon
+or by `lerim working-memory refresh`, so `show`, `status`, and `path` should be
+fast local reads.
+
+```mermaid
+flowchart TD
+    A["Agent starts in a repo"] --> B["lerim working-memory show"]
+    B --> C{"Current markdown exists?"}
+    C -- "yes" --> D["Read generated context"]
+    C -- "no" --> E["lerim working-memory status"]
+    E --> F["Run or suggest refresh"]
+    D --> G{"Need exact or deeper context?"}
+    G -- "exact" --> H["lerim query"]
+    G -- "synthesis" --> I["lerim ask"]
+    G -- "no" --> J["Continue work"]
+```
+
 ## Working rules
 
+- Working Memory is a generated markdown view of SQLite records, not durable state.
+- Read the freshness block. If it reports changed records and newest context matters, suggest `lerim working-memory refresh`.
+- Use `lerim working-memory status` to see dynamic age, record-change count, current path, latest run, and suggested action.
+- Use `lerim working-memory path` when another tool needs the stable Markdown path.
+- Do not hardcode project IDs. Run commands from inside the repo or pass `--project <name-or-path>`.
 - Prefer `query` over `ask` when the question is exact.
 - Prefer `ask` over manual browsing when the question needs synthesis across records.
 - Treat Lerim as the context layer, not as a place to manually edit durable state during normal coding work.

--- a/src/lerim/skills/cli-reference.md
+++ b/src/lerim/skills/cli-reference.md
@@ -224,7 +224,7 @@ Generated markdown startup context for coding agents. The markdown lives under
 view of `~/.lerim/context.sqlite3`, not a second memory store.
 
 ```bash
-lerim working-memory show              # print current generated markdown
+lerim working-memory show              # print live DB freshness + markdown
 lerim working-memory status            # show freshness metadata
 lerim working-memory path              # print stable current file path
 lerim working-memory refresh           # regenerate if records changed
@@ -233,8 +233,8 @@ lerim working-memory refresh --force   # regenerate even if unchanged
 
 | Subcommand | Description |
 |------------|-------------|
-| `show` | Print the current `WORKING_MEMORY.md` without model calls |
-| `status` | Print availability, generated time, age, records included, changed-record count, current path, latest run, and suggested action |
+| `show` | Print live DB freshness plus the current `WORKING_MEMORY.md` without model calls |
+| `status` | Print availability, generated time, age, records included, DB changed-record count, current path, latest run, and suggested action |
 | `path` | Print the stable expected current artifact path |
 | `refresh` | Generate dated artifacts and update the stable current copy |
 
@@ -244,9 +244,27 @@ lerim working-memory refresh --force   # regenerate even if unchanged
 | `--force` | On `refresh`, regenerate even when no context records changed |
 | `--json` | Emit structured JSON for `status`, `path`, and `refresh` |
 
+Rendered artifact shape:
+
+| Section | Source |
+|---------|--------|
+| `Summary` | Compact cited startup cache |
+| `Start Here` | Deterministic Lerim guidance for repo scope, freshness, git state, and verification |
+| `Current Handoff` | Recent episode evidence only; otherwise an explicit no-handoff note |
+| `Decisions` | Durable decision records |
+| `Constraints & Preferences` | Durable constraint and preference records |
+| `Project Facts` | Durable facts and references that prevent mistakes |
+| `Open Risks / Review Queue` | Records that explicitly identify unresolved work, risks, or review concerns |
+| `Follow-up Queries` | Records that explicitly justify deeper lookup questions |
+| `Sources` | Cited record IDs used by the body |
+
 Notes:
 - Coding agents should call `lerim working-memory show` instead of hardcoding a `project_id`.
-- Use `lerim working-memory status` for dynamic freshness: current age, record-change count, current path, latest run folder, and suggested action.
+- Use `lerim working-memory status` for dynamic freshness: current age, DB record-change count, current path, latest run folder, and suggested action.
+- Treat test/build results inside Working Memory as historical persisted evidence; rerun relevant checks after edits.
+- `show` prepends live DB freshness; the markdown that follows is still the last generated snapshot.
+- `Start Here` is deterministic. Do not read it as model-written evidence.
+- `Current Handoff` is valid only when backed by recent episode records.
 - Daily daemon refresh and maintain-triggered refresh skip unchanged projects.
 - Sync does not directly trigger Working Memory in v1.
 
@@ -255,14 +273,14 @@ Flow:
 ```mermaid
 flowchart TD
     A["manual refresh, daily daemon, or maintain trigger"] --> B["resolve registered project"]
-    B --> C["count changed record_versions since generated_at"]
+    B --> C["count changed DB record_versions since generated_at"]
     C --> D{"current artifact exists and changed count is 0?"}
     D -- "yes" --> E["skip without model call"]
     D -- "no or --force" --> F["load active candidate records"]
     F --> G{"candidate records exist?"}
     G -- "no" --> H["render empty-state markdown"]
     G -- "yes" --> I["run Working Memory synthesis agent"]
-    I --> J["validate cited record IDs"]
+    I --> J["validate cited record IDs and fixed sections"]
     H --> K["write dated run artifacts"]
     J --> K
     K --> L["copy latest files to workspace/current/<project_id>"]

--- a/src/lerim/skills/cli-reference.md
+++ b/src/lerim/skills/cli-reference.md
@@ -11,6 +11,9 @@ Commands that call the HTTP API (`ask`, `sync`, `maintain`, `status`) require a
 running server (`lerim up` or `lerim serve`). `unscoped` also requires the running
 API. Most other commands are **host-only**
 (local files, Docker CLI, local SQLite state).
+`working-memory show`, `working-memory status`, and `working-memory path` are
+fast local reads. `working-memory refresh` runs local generation for the resolved
+project and records a service run.
 
 ## Global flags
 
@@ -36,6 +39,7 @@ API. Most other commands are **host-only**
 - `connect`
 - `sync`
 - `maintain`
+- `working-memory` (`show`, `status`, `path`, `refresh`) (host-only)
 - `dashboard`
 - `ask`
 - `query`
@@ -213,10 +217,62 @@ lerim maintain --dry-run      # preview only, no writes
 |------|-------------|
 | `--dry-run` | Record a run but skip actual record changes |
 
+### `lerim working-memory` (host-only)
+
+Generated markdown startup context for coding agents. The markdown lives under
+`~/.lerim/workspace/current/<project_id>/WORKING_MEMORY.md` and is a derived
+view of `~/.lerim/context.sqlite3`, not a second memory store.
+
+```bash
+lerim working-memory show              # print current generated markdown
+lerim working-memory status            # show freshness metadata
+lerim working-memory path              # print stable current file path
+lerim working-memory refresh           # regenerate if records changed
+lerim working-memory refresh --force   # regenerate even if unchanged
+```
+
+| Subcommand | Description |
+|------------|-------------|
+| `show` | Print the current `WORKING_MEMORY.md` without model calls |
+| `status` | Print availability, generated time, age, records included, changed-record count, current path, latest run, and suggested action |
+| `path` | Print the stable expected current artifact path |
+| `refresh` | Generate dated artifacts and update the stable current copy |
+
+| Flag | Description |
+|------|-------------|
+| `--project` | Registered project name or path. Defaults to the project resolved from cwd |
+| `--force` | On `refresh`, regenerate even when no context records changed |
+| `--json` | Emit structured JSON for `status`, `path`, and `refresh` |
+
+Notes:
+- Coding agents should call `lerim working-memory show` instead of hardcoding a `project_id`.
+- Use `lerim working-memory status` for dynamic freshness: current age, record-change count, current path, latest run folder, and suggested action.
+- Daily daemon refresh and maintain-triggered refresh skip unchanged projects.
+- Sync does not directly trigger Working Memory in v1.
+
+Flow:
+
+```mermaid
+flowchart TD
+    A["manual refresh, daily daemon, or maintain trigger"] --> B["resolve registered project"]
+    B --> C["count changed record_versions since generated_at"]
+    C --> D{"current artifact exists and changed count is 0?"}
+    D -- "yes" --> E["skip without model call"]
+    D -- "no or --force" --> F["load active candidate records"]
+    F --> G{"candidate records exist?"}
+    G -- "no" --> H["render empty-state markdown"]
+    G -- "yes" --> I["run Working Memory synthesis agent"]
+    I --> J["validate cited record IDs"]
+    H --> K["write dated run artifacts"]
+    J --> K
+    K --> L["copy latest files to workspace/current/<project_id>"]
+```
+
 ### Background sync and maintain
 
 There is **no** separate `lerim daemon` command. The daemon loop (sync + maintain
-on `sync_interval_minutes` / `maintain_interval_minutes`) runs **inside**
+on `sync_interval_minutes` / `maintain_interval_minutes`, plus daily Working Memory)
+runs **inside**
 `lerim serve` and therefore inside `lerim up` (Docker).
 
 ### `lerim dashboard`

--- a/src/lerim/working_memory.py
+++ b/src/lerim/working_memory.py
@@ -19,6 +19,7 @@ WORKING_MEMORY_OPERATION = "working-memory"
 MAX_CANDIDATE_RECORDS = 80
 TARGET_LINE_COUNT = 50
 MAX_LINE_COUNT = 80
+REFERENCE_LINE_LIMIT = 12
 KIND_PRIORITY = {
     "decision": 0,
     "preference": 1,
@@ -26,6 +27,14 @@ KIND_PRIORITY = {
     "fact": 3,
     "reference": 4,
     "episode": 5,
+}
+KIND_BUDGETS = {
+    "decision": 20,
+    "preference": 10,
+    "constraint": 14,
+    "fact": 14,
+    "reference": 8,
+    "episode": 8,
 }
 
 
@@ -67,7 +76,14 @@ class WorkingMemoryDraft:
     """Structured synthesized Working Memory content before markdown rendering."""
 
     summary: tuple[MemoryLine, ...]
-    sections: tuple[MemorySection, ...]
+    start_here: tuple[MemoryLine, ...] = ()
+    current_handoff: tuple[MemoryLine, ...] = ()
+    decisions: tuple[MemoryLine, ...] = ()
+    constraints_preferences: tuple[MemoryLine, ...] = ()
+    project_facts: tuple[MemoryLine, ...] = ()
+    open_risks: tuple[MemoryLine, ...] = ()
+    follow_up_queries: tuple[MemoryLine, ...] = ()
+    sections: tuple[MemorySection, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -255,7 +271,26 @@ def load_candidate_records(
     project_id: str,
     limit: int = MAX_CANDIDATE_RECORDS,
 ) -> list[dict[str, Any]]:
-    """Load bounded active records ordered by durable-kind priority."""
+    """Load bounded active records with durable-kind and recency balance."""
+    protected_ids: list[str] = []
+    protected_by_id: dict[str, dict[str, Any]] = {}
+    for kind, budget in KIND_BUDGETS.items():
+        payload = store.query(
+            entity="records",
+            mode="list",
+            project_ids=[project_id],
+            kind=kind,
+            status="active",
+            order_by="updated_at",
+            limit=max(1, int(budget)),
+            include_total=False,
+        )
+        for row in payload.get("rows") or []:
+            record_id = str(row.get("record_id") or "")
+            if record_id and record_id not in protected_by_id:
+                protected_ids.append(record_id)
+                protected_by_id[record_id] = row
+
     payload = store.query(
         entity="records",
         mode="list",
@@ -265,26 +300,44 @@ def load_candidate_records(
         limit=max(1, int(limit)),
         include_total=False,
     )
-    rows = list(payload.get("rows") or [])
+    row_by_id = dict(protected_by_id)
+    for row in payload.get("rows") or []:
+        record_id = str(row.get("record_id") or "")
+        if record_id:
+            row_by_id.setdefault(record_id, row)
+
+    protected = [protected_by_id[record_id] for record_id in protected_ids]
+    fill = [
+        row
+        for record_id, row in row_by_id.items()
+        if record_id not in protected_by_id
+    ]
+    sort_candidates(protected)
+    sort_candidates(fill)
+    rows = protected[: max(1, int(limit))] + fill
+    return rows[: max(1, int(limit))]
+
+
+def sort_candidates(rows: list[dict[str, Any]]) -> None:
+    """Sort candidate rows by kind priority, then newest update first."""
     rows.sort(
-        key=lambda row: (str(row.get("updated_at") or ""), str(row.get("record_id") or "")),
+        key=lambda row: (
+            str(row.get("updated_at") or ""),
+            str(row.get("record_id") or ""),
+        ),
         reverse=True,
     )
     rows.sort(key=lambda row: KIND_PRIORITY.get(str(row.get("kind") or ""), 50))
-    return rows[: max(1, int(limit))]
 
 
 def empty_working_memory_draft() -> WorkingMemoryDraft:
     """Return an empty draft for projects with no active context records."""
-    return WorkingMemoryDraft(summary=(), sections=())
+    return WorkingMemoryDraft(summary=())
 
 
 def validate_draft(draft: WorkingMemoryDraft, *, allowed_record_ids: set[str]) -> None:
     """Validate that every substantive line has a known record citation."""
-    lines = [*draft.summary]
-    for section in draft.sections:
-        lines.extend(section.lines)
-    for line in lines:
+    for line in iter_draft_lines(draft):
         if not line.text.strip():
             continue
         if not line.record_ids:
@@ -294,39 +347,100 @@ def validate_draft(draft: WorkingMemoryDraft, *, allowed_record_ids: set[str]) -
             raise ValueError(f"working_memory_line_unknown_record_id:{unknown[0]}")
 
 
-def included_record_ids(draft: WorkingMemoryDraft) -> tuple[str, ...]:
-    """Return sorted unique record IDs cited by the draft."""
-    seen: set[str] = set()
-    for line in draft.summary:
-        seen.update(line.record_ids)
+def iter_draft_lines(draft: WorkingMemoryDraft) -> tuple[MemoryLine, ...]:
+    """Return all synthesized memory lines in rendered section order."""
+    lines: list[MemoryLine] = []
+    lines.extend(draft.summary)
+    lines.extend(draft.start_here)
+    lines.extend(draft.current_handoff)
+    lines.extend(draft.decisions)
+    lines.extend(draft.constraints_preferences)
+    lines.extend(draft.project_facts)
+    lines.extend(draft.open_risks)
+    lines.extend(draft.follow_up_queries)
     for section in draft.sections:
-        for line in section.lines:
-            seen.update(line.record_ids)
-    return tuple(sorted(seen))
+        lines.extend(section.lines)
+    return tuple(lines)
+
+
+def included_record_ids(draft: WorkingMemoryDraft) -> tuple[str, ...]:
+    """Return unique record IDs in first-citation order."""
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for line in iter_draft_lines(draft):
+        for record_id in line.record_ids:
+            if record_id not in seen:
+                seen.add(record_id)
+                ordered.append(record_id)
+    return tuple(ordered)
 
 
 def render_working_memory_markdown(
     *,
     project: WorkingMemoryProject,
     generated_at: str,
+    previous_generated_at: str | None,
+    generation_trigger: str,
+    records_considered: int,
     records_included: int,
-    changed_since_generation: int,
+    db_records_changed_since_previous: int,
     draft: WorkingMemoryDraft,
+    candidate_records: list[dict[str, Any]] | None = None,
+    current_file: Path | None = None,
+    run_folder: Path | None = None,
 ) -> str:
     """Render Working Memory markdown with freshness metadata and citations."""
     lines = [
         "# Working Memory",
         "",
         "> Generated from Lerim SQLite context. This markdown is a derived view, not the source of truth.",
+        "> It reflects persisted Lerim records only. Check git status, tests, and the current chat for live workspace state.",
         "",
         f"- Project: `{project.name}` (`{project.identity.project_id}`)",
-        f"- Generated: `{generated_at}` ({human_age(age_seconds_since(generated_at))})",
-        f"- Records included: {records_included}",
-        f"- Records changed since generation: {changed_since_generation}",
+        f"- Generated: `{generated_at}`",
+        f"- Previous generation: `{previous_generated_at or 'none'}`",
+        f"- Generation trigger: `{generation_trigger}`",
+        f"- Records considered: {records_considered}",
+        f"- Records cited: {records_included}",
+        f"- DB records changed before this generation: {db_records_changed_since_previous}",
+        "- Live DB freshness: `lerim working-memory status`",
         "- Refresh: `lerim working-memory refresh`",
+        "- Inspect sources: use the Sources section below, or run "
+        f"`lerim query records list --scope project --project {project.identity.repo_path} --json`.",
         "",
     ]
-    if not draft.summary and not draft.sections:
+    if current_file is not None:
+        lines.append(f"- Current file: `{current_file}`")
+    if run_folder is not None:
+        lines.append(f"- Run folder: `{run_folder}`")
+    if current_file is not None or run_folder is not None:
+        lines.append("")
+    has_episode_evidence = any(
+        str(record.get("kind") or "") == "episode"
+        for record in candidate_records or []
+    )
+    seen_lines: set[str] = set()
+    lines.extend(
+        [
+            "## Start Here",
+            "",
+            f"- Memory scope: `{project.identity.repo_path}` (`{project.name}`).",
+            f"- To read this exact memory from another cwd, pass `--project {project.identity.repo_path}`.",
+            "- Code/package work may live in a child directory; use more specific Project Facts paths for code and tests.",
+            "- Run `git status` before editing; Working Memory is DB context, not workspace state.",
+            "- Treat any test/build results below as historical persisted evidence; rerun relevant checks after edits.",
+        ]
+    )
+    for item in draft.start_here[:6]:
+        rendered = render_memory_line(item, seen_lines=seen_lines)
+        if rendered:
+            lines.append(rendered)
+    if not has_episode_evidence:
+        lines.append(
+            "- No implementation handoff is available from persisted episode records; use the current chat, tests, and git state for live work."
+        )
+    lines.append("")
+    if not iter_draft_lines(draft):
         lines.extend(
             [
                 "## Summary",
@@ -334,18 +448,194 @@ def render_working_memory_markdown(
                 "No active project context records exist yet. Run `lerim sync` and `lerim maintain` to build context.",
             ]
         )
-        return "\n".join(lines[:MAX_LINE_COUNT]).rstrip() + "\n"
+        return "\n".join(truncate_markdown_lines(lines)).rstrip() + "\n"
 
-    lines.extend(["## Summary", ""])
-    for item in draft.summary[:8]:
-        lines.append(f"- {item.text.strip()} {format_citations(item.record_ids)}")
+    append_memory_section(
+        lines,
+        title="Summary",
+        items=draft.summary[:8],
+        seen_lines=seen_lines,
+    )
+    cited_ids = included_record_ids(draft)
+    if cited_ids and not any(
+        str(record.get("kind") or "") == "episode"
+        for record in candidate_records or []
+        if str(record.get("record_id") or "") in cited_ids
+    ):
+        lines.extend(
+            [
+                "",
+                "> No recent episode records were cited. Treat this as durable context, not a complete handoff of current work.",
+            ]
+        )
+    append_memory_section(
+        lines,
+        title="Current Handoff",
+        items=draft.current_handoff[:10],
+        seen_lines=seen_lines,
+    )
+    append_memory_section(
+        lines,
+        title="Decisions",
+        items=draft.decisions[:12],
+        seen_lines=seen_lines,
+    )
+    append_memory_section(
+        lines,
+        title="Constraints & Preferences",
+        items=draft.constraints_preferences[:12],
+        seen_lines=seen_lines,
+    )
+    append_memory_section(
+        lines,
+        title="Project Facts",
+        items=draft.project_facts[:12],
+        seen_lines=seen_lines,
+    )
+    append_memory_section(
+        lines,
+        title="Open Risks / Review Queue",
+        items=draft.open_risks[:10],
+        seen_lines=seen_lines,
+    )
+    append_memory_section(
+        lines,
+        title="Follow-up Queries",
+        items=draft.follow_up_queries[:8],
+        seen_lines=seen_lines,
+    )
     for section in draft.sections:
         if not section.lines:
             continue
-        lines.extend(["", f"## {section.title.strip()}", ""])
-        for item in section.lines[:14]:
-            lines.append(f"- {item.text.strip()} {format_citations(item.record_ids)}")
-    return "\n".join(lines[:MAX_LINE_COUNT]).rstrip() + "\n"
+        append_memory_section(
+            lines,
+            title=section.title.strip(),
+            items=section.lines[:14],
+            seen_lines=seen_lines,
+        )
+    source_lines = format_source_reference_lines(
+        candidate_records or [],
+        cited_record_ids=included_record_ids(draft),
+    )
+    if source_lines:
+        lines = append_sources_with_budget(lines, source_lines)
+    else:
+        lines = truncate_markdown_lines(lines)
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def clean_memory_text(text: str, record_ids: tuple[str, ...]) -> str:
+    """Remove accidental inline record IDs from model-written memory text."""
+    cleaned = str(text or "").strip()
+    for record_id in record_ids:
+        cleaned = cleaned.replace(str(record_id), "")
+    for token in ("[]", "()", "(,)", "[,]"):
+        cleaned = cleaned.replace(token, "")
+    return " ".join(cleaned.split()).strip(" -:;,")
+
+
+def render_memory_line(
+    item: MemoryLine,
+    *,
+    seen_lines: set[str],
+) -> str | None:
+    """Render one deduped memory bullet."""
+    cleaned = clean_memory_text(item.text, item.record_ids)
+    if not cleaned:
+        return None
+    normalized = cleaned.casefold()
+    if normalized in seen_lines:
+        return None
+    seen_lines.add(normalized)
+    return f"- {cleaned} {format_citations(item.record_ids)}"
+
+
+def append_memory_section(
+    lines: list[str],
+    *,
+    title: str,
+    items: tuple[MemoryLine, ...],
+    seen_lines: set[str],
+) -> None:
+    """Append a fixed Working Memory section when it has rendered lines."""
+    section_lines: list[str] = []
+    for item in items:
+        rendered = render_memory_line(item, seen_lines=seen_lines)
+        if rendered:
+            section_lines.append(rendered)
+    if section_lines:
+        lines.extend(["", f"## {title}", "", *section_lines])
+
+
+def format_source_reference_lines(
+    records: list[dict[str, Any]],
+    *,
+    cited_record_ids: tuple[str, ...],
+) -> list[str]:
+    """Render compact source lines for cited records."""
+    by_id = {str(record.get("record_id") or ""): record for record in records}
+    lines: list[str] = []
+    for record_id in cited_record_ids[:REFERENCE_LINE_LIMIT]:
+        record = by_id.get(record_id)
+        if not record:
+            continue
+        title = str(record.get("title") or "Untitled").strip()
+        kind = str(record.get("kind") or "record").strip()
+        updated_at = str(record.get("updated_at") or "").strip()
+        source_session = str(record.get("source_session_id") or "").strip()
+        source_text = f"; source_session: `{source_session}`" if source_session else ""
+        lines.append(
+            f"- `{record_id}` ({kind}, updated `{updated_at}`): {title}{source_text}"
+        )
+    if len(cited_record_ids) > REFERENCE_LINE_LIMIT:
+        remaining = len(cited_record_ids) - REFERENCE_LINE_LIMIT
+        lines.append(
+            f"- {remaining} more cited source(s); run `lerim working-memory status` "
+            "and `lerim query records list --json` for full DB details."
+        )
+    return lines
+
+
+def truncate_markdown_lines(lines: list[str]) -> list[str]:
+    """Return markdown lines with an explicit truncation marker when clipped."""
+    if len(lines) <= MAX_LINE_COUNT:
+        return lines
+    visible = lines[: max(0, MAX_LINE_COUNT - 3)]
+    visible.extend(
+        [
+            "",
+            "> Truncated for startup size. Use `lerim query` or `lerim ask` for deeper context.",
+        ]
+    )
+    return visible
+
+
+def append_sources_with_budget(lines: list[str], source_lines: list[str]) -> list[str]:
+    """Append sources while preserving them under the max line budget."""
+    sources_block = ["", "## Sources", "", *source_lines]
+    if len(lines) + len(sources_block) <= MAX_LINE_COUNT:
+        return [*lines, *sources_block]
+    reserved = len(sources_block) + 3
+    body_budget = max(0, MAX_LINE_COUNT - reserved)
+    body = lines[:body_budget]
+    strip_dangling_section_header(body)
+    body.extend(
+        [
+            "",
+            "> Body truncated for startup size. Sources are preserved below.",
+        ]
+    )
+    return [*body, *sources_block]
+
+
+def strip_dangling_section_header(lines: list[str]) -> None:
+    """Remove a trailing empty section header after body truncation."""
+    while lines and not lines[-1].strip():
+        lines.pop()
+    if lines and lines[-1].startswith("## "):
+        lines.pop()
+    while lines and not lines[-1].strip():
+        lines.pop()
 
 
 def format_citations(record_ids: tuple[str, ...]) -> str:
@@ -364,6 +654,7 @@ def build_manifest(
     records_included: int,
     included_record_ids_value: tuple[str, ...],
     changed_records_since_previous: int,
+    trigger: str,
     current_file: Path,
     run_folder: Path,
 ) -> dict[str, Any]:
@@ -373,6 +664,7 @@ def build_manifest(
         "operation": WORKING_MEMORY_OPERATION,
         "status": status,
         "generated_at": generated_at,
+        "trigger": trigger,
         "project_id": project.identity.project_id,
         "project": project.name,
         "repo_path": str(project.identity.repo_path),
@@ -406,15 +698,15 @@ def working_memory_status(
     if not file_exists:
         availability = "missing"
         action = "Run `lerim working-memory refresh`."
-    elif changed > 0:
-        availability = "stale"
-        action = "Read the file, then run `lerim working-memory refresh` if newest context matters."
     elif not manifest_exists:
         availability = "error"
         action = "Run `lerim working-memory refresh --force`."
+    elif changed > 0:
+        availability = "stale"
+        action = "Refresh if newest persisted DB context matters."
     else:
         availability = "available"
-        action = "Read with `lerim working-memory show`."
+        action = "Continue with this startup context; inspect sources or query deeper if needed."
     return WorkingMemoryStatus(
         availability=availability,
         project=project.name,

--- a/src/lerim/working_memory.py
+++ b/src/lerim/working_memory.py
@@ -1,0 +1,457 @@
+"""Generated Working Memory use case for fast agent startup context."""
+
+from __future__ import annotations
+
+import json
+import shutil
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Protocol
+
+from lerim.config.project_scope import match_session_project
+from lerim.config.settings import Config
+from lerim.context import ContextStore, ProjectIdentity, resolve_project_identity
+
+WORKING_MEMORY_FILENAME = "WORKING_MEMORY.md"
+WORKING_MEMORY_MANIFEST_FILENAME = "manifest.json"
+WORKING_MEMORY_OPERATION = "working-memory"
+MAX_CANDIDATE_RECORDS = 80
+TARGET_LINE_COUNT = 50
+MAX_LINE_COUNT = 80
+KIND_PRIORITY = {
+    "decision": 0,
+    "preference": 1,
+    "constraint": 2,
+    "fact": 3,
+    "reference": 4,
+    "episode": 5,
+}
+
+
+@dataclass(frozen=True)
+class WorkingMemoryProject:
+    """Resolved project metadata for Working Memory commands."""
+
+    name: str
+    identity: ProjectIdentity
+
+
+@dataclass(frozen=True)
+class WorkingMemoryPaths:
+    """Stable current Working Memory artifact paths for one project."""
+
+    current_dir: Path
+    current_file: Path
+    current_manifest: Path
+
+
+@dataclass(frozen=True)
+class MemoryLine:
+    """One cited Working Memory line returned by synthesis."""
+
+    text: str
+    record_ids: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class MemorySection:
+    """One rendered Working Memory section."""
+
+    title: str
+    lines: tuple[MemoryLine, ...]
+
+
+@dataclass(frozen=True)
+class WorkingMemoryDraft:
+    """Structured synthesized Working Memory content before markdown rendering."""
+
+    summary: tuple[MemoryLine, ...]
+    sections: tuple[MemorySection, ...]
+
+
+@dataclass(frozen=True)
+class WorkingMemoryStatus:
+    """Freshness and availability metadata for one project's current artifact."""
+
+    availability: str
+    project: str
+    project_id: str
+    repo_path: str
+    generated_at: str | None
+    age_seconds: int | None
+    records_included: int
+    records_changed_since_generation: int
+    current_file: str
+    current_manifest: str
+    latest_run_folder: str | None
+    suggested_action: str
+
+
+@dataclass(frozen=True)
+class WorkingMemoryGenerationResult:
+    """Result payload for a refresh attempt."""
+
+    status: str
+    project: str
+    project_id: str
+    generated_at: str | None
+    records_considered: int
+    records_included: int
+    records_changed_since_previous: int
+    included_record_ids: tuple[str, ...]
+    current_file: str
+    current_manifest: str
+    run_folder: str | None
+    skip_reason: str | None = None
+
+
+class WorkingMemorySynthesizer(Protocol):
+    """Port for compressing candidate context records into cited sections."""
+
+    def __call__(self, candidates: list[dict[str, Any]]) -> WorkingMemoryDraft:
+        """Return a cited Working Memory draft for candidate records."""
+
+
+def utc_now_iso() -> str:
+    """Return current UTC time as ISO text."""
+    return datetime.now(timezone.utc).isoformat()
+
+
+def parse_iso_datetime(raw: str | None) -> datetime | None:
+    """Parse an ISO timestamp into an aware UTC datetime when possible."""
+    text = str(raw or "").strip()
+    if not text:
+        return None
+    try:
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def age_seconds_since(raw: str | None, *, now: datetime | None = None) -> int | None:
+    """Return elapsed seconds since an ISO timestamp."""
+    parsed = parse_iso_datetime(raw)
+    if parsed is None:
+        return None
+    effective_now = now or datetime.now(timezone.utc)
+    return max(0, int((effective_now - parsed).total_seconds()))
+
+
+def human_age(seconds: int | None) -> str:
+    """Render an elapsed duration in compact human form."""
+    if seconds is None:
+        return "unknown age"
+    if seconds < 60:
+        return f"{seconds}s ago"
+    if seconds < 3600:
+        return f"{seconds // 60}m ago"
+    if seconds < 86400:
+        return f"{seconds // 3600}h ago"
+    return f"{seconds // 86400}d ago"
+
+
+def working_memory_paths(config: Config, project_id: str) -> WorkingMemoryPaths:
+    """Return stable current Working Memory paths for a project."""
+    current_dir = config.global_data_dir / "workspace" / "current" / project_id
+    return WorkingMemoryPaths(
+        current_dir=current_dir,
+        current_file=current_dir / WORKING_MEMORY_FILENAME,
+        current_manifest=current_dir / WORKING_MEMORY_MANIFEST_FILENAME,
+    )
+
+
+def resolve_working_memory_project(
+    *,
+    config: Config,
+    project: str | None = None,
+    cwd: Path | None = None,
+) -> WorkingMemoryProject:
+    """Resolve a project name/path or cwd into a registered project identity."""
+    projects = config.projects or {}
+    if not projects:
+        raise ValueError("No registered projects. Add one with `lerim project add <path>`.")
+
+    if project:
+        token = str(project).strip()
+        if token in projects:
+            project_path = Path(projects[token]).expanduser().resolve()
+            return WorkingMemoryProject(
+                name=token,
+                identity=resolve_project_identity(project_path),
+            )
+        try:
+            candidate = Path(token).expanduser().resolve()
+        except OSError as exc:
+            raise ValueError(f"Project not found: {project}") from exc
+        match = match_session_project(str(candidate), projects)
+        if match is None:
+            raise ValueError(f"Project not found: {project}")
+        name, project_path = match
+        return WorkingMemoryProject(
+            name=name,
+            identity=resolve_project_identity(project_path),
+        )
+
+    candidate_cwd = (cwd or Path.cwd()).expanduser().resolve()
+    match = match_session_project(str(candidate_cwd), projects)
+    if match is None:
+        raise ValueError(
+            "Current directory is not inside a registered Lerim project. "
+            "Run `lerim project add <path>` or pass `--project <name-or-path>`."
+        )
+    name, project_path = match
+    return WorkingMemoryProject(
+        name=name,
+        identity=resolve_project_identity(project_path),
+    )
+
+
+def read_manifest(path: Path) -> dict[str, Any] | None:
+    """Read a manifest JSON object, returning None when unavailable."""
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def count_changed_records_since(
+    store: ContextStore,
+    *,
+    project_id: str,
+    since: str | None,
+) -> int:
+    """Count distinct project records changed after the provided timestamp."""
+    store.initialize()
+    with store.connect() as conn:
+        if since:
+            row = conn.execute(
+                """
+                SELECT COUNT(DISTINCT record_id) AS total
+                FROM record_versions
+                WHERE project_id = ? AND changed_at > ?
+                """,
+                (project_id, since),
+            ).fetchone()
+        else:
+            row = conn.execute(
+                """
+                SELECT COUNT(1) AS total
+                FROM records
+                WHERE project_id = ? AND status = 'active'
+                """,
+                (project_id,),
+            ).fetchone()
+    return int(row["total"] or 0) if row else 0
+
+
+def load_candidate_records(
+    store: ContextStore,
+    *,
+    project_id: str,
+    limit: int = MAX_CANDIDATE_RECORDS,
+) -> list[dict[str, Any]]:
+    """Load bounded active records ordered by durable-kind priority."""
+    payload = store.query(
+        entity="records",
+        mode="list",
+        project_ids=[project_id],
+        status="active",
+        order_by="updated_at",
+        limit=max(1, int(limit)),
+        include_total=False,
+    )
+    rows = list(payload.get("rows") or [])
+    rows.sort(
+        key=lambda row: (str(row.get("updated_at") or ""), str(row.get("record_id") or "")),
+        reverse=True,
+    )
+    rows.sort(key=lambda row: KIND_PRIORITY.get(str(row.get("kind") or ""), 50))
+    return rows[: max(1, int(limit))]
+
+
+def empty_working_memory_draft() -> WorkingMemoryDraft:
+    """Return an empty draft for projects with no active context records."""
+    return WorkingMemoryDraft(summary=(), sections=())
+
+
+def validate_draft(draft: WorkingMemoryDraft, *, allowed_record_ids: set[str]) -> None:
+    """Validate that every substantive line has a known record citation."""
+    lines = [*draft.summary]
+    for section in draft.sections:
+        lines.extend(section.lines)
+    for line in lines:
+        if not line.text.strip():
+            continue
+        if not line.record_ids:
+            raise ValueError("working_memory_line_missing_record_id")
+        unknown = [record_id for record_id in line.record_ids if record_id not in allowed_record_ids]
+        if unknown:
+            raise ValueError(f"working_memory_line_unknown_record_id:{unknown[0]}")
+
+
+def included_record_ids(draft: WorkingMemoryDraft) -> tuple[str, ...]:
+    """Return sorted unique record IDs cited by the draft."""
+    seen: set[str] = set()
+    for line in draft.summary:
+        seen.update(line.record_ids)
+    for section in draft.sections:
+        for line in section.lines:
+            seen.update(line.record_ids)
+    return tuple(sorted(seen))
+
+
+def render_working_memory_markdown(
+    *,
+    project: WorkingMemoryProject,
+    generated_at: str,
+    records_included: int,
+    changed_since_generation: int,
+    draft: WorkingMemoryDraft,
+) -> str:
+    """Render Working Memory markdown with freshness metadata and citations."""
+    lines = [
+        "# Working Memory",
+        "",
+        "> Generated from Lerim SQLite context. This markdown is a derived view, not the source of truth.",
+        "",
+        f"- Project: `{project.name}` (`{project.identity.project_id}`)",
+        f"- Generated: `{generated_at}` ({human_age(age_seconds_since(generated_at))})",
+        f"- Records included: {records_included}",
+        f"- Records changed since generation: {changed_since_generation}",
+        "- Refresh: `lerim working-memory refresh`",
+        "",
+    ]
+    if not draft.summary and not draft.sections:
+        lines.extend(
+            [
+                "## Summary",
+                "",
+                "No active project context records exist yet. Run `lerim sync` and `lerim maintain` to build context.",
+            ]
+        )
+        return "\n".join(lines[:MAX_LINE_COUNT]).rstrip() + "\n"
+
+    lines.extend(["## Summary", ""])
+    for item in draft.summary[:8]:
+        lines.append(f"- {item.text.strip()} {format_citations(item.record_ids)}")
+    for section in draft.sections:
+        if not section.lines:
+            continue
+        lines.extend(["", f"## {section.title.strip()}", ""])
+        for item in section.lines[:14]:
+            lines.append(f"- {item.text.strip()} {format_citations(item.record_ids)}")
+    return "\n".join(lines[:MAX_LINE_COUNT]).rstrip() + "\n"
+
+
+def format_citations(record_ids: tuple[str, ...]) -> str:
+    """Format record citations for a rendered markdown line."""
+    cleaned = [record_id for record_id in record_ids if record_id]
+    return "[" + ", ".join(cleaned) + "]" if cleaned else ""
+
+
+def build_manifest(
+    *,
+    run_id: str,
+    status: str,
+    generated_at: str,
+    project: WorkingMemoryProject,
+    records_considered: int,
+    records_included: int,
+    included_record_ids_value: tuple[str, ...],
+    changed_records_since_previous: int,
+    current_file: Path,
+    run_folder: Path,
+) -> dict[str, Any]:
+    """Build the Working Memory manifest payload."""
+    return {
+        "run_id": run_id,
+        "operation": WORKING_MEMORY_OPERATION,
+        "status": status,
+        "generated_at": generated_at,
+        "project_id": project.identity.project_id,
+        "project": project.name,
+        "repo_path": str(project.identity.repo_path),
+        "records_considered": records_considered,
+        "records_included": records_included,
+        "included_record_ids": list(included_record_ids_value),
+        "changed_records_since_previous": changed_records_since_previous,
+        "current_file": str(current_file),
+        "run_folder": str(run_folder),
+    }
+
+
+def working_memory_status(
+    *,
+    config: Config,
+    store: ContextStore,
+    project: WorkingMemoryProject,
+) -> WorkingMemoryStatus:
+    """Compute current Working Memory freshness and availability."""
+    paths = working_memory_paths(config, project.identity.project_id)
+    manifest = read_manifest(paths.current_manifest) or {}
+    generated_at = str(manifest.get("generated_at") or "").strip() or None
+    changed = count_changed_records_since(
+        store,
+        project_id=project.identity.project_id,
+        since=generated_at,
+    )
+    age = age_seconds_since(generated_at)
+    file_exists = paths.current_file.is_file()
+    manifest_exists = paths.current_manifest.is_file()
+    if not file_exists:
+        availability = "missing"
+        action = "Run `lerim working-memory refresh`."
+    elif changed > 0:
+        availability = "stale"
+        action = "Read the file, then run `lerim working-memory refresh` if newest context matters."
+    elif not manifest_exists:
+        availability = "error"
+        action = "Run `lerim working-memory refresh --force`."
+    else:
+        availability = "available"
+        action = "Read with `lerim working-memory show`."
+    return WorkingMemoryStatus(
+        availability=availability,
+        project=project.name,
+        project_id=project.identity.project_id,
+        repo_path=str(project.identity.repo_path),
+        generated_at=generated_at,
+        age_seconds=age,
+        records_included=int(manifest.get("records_included") or 0),
+        records_changed_since_generation=changed,
+        current_file=str(paths.current_file),
+        current_manifest=str(paths.current_manifest),
+        latest_run_folder=str(manifest.get("run_folder") or "") or None,
+        suggested_action=action,
+    )
+
+
+def write_current_artifacts(
+    *,
+    paths: WorkingMemoryPaths,
+    run_markdown: Path,
+    run_manifest: Path,
+) -> None:
+    """Copy dated artifacts into the stable current location."""
+    paths.current_dir.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(run_markdown, paths.current_file)
+    shutil.copyfile(run_manifest, paths.current_manifest)
+
+
+def status_to_dict(status: WorkingMemoryStatus) -> dict[str, Any]:
+    """Convert status dataclass to JSON-ready dict."""
+    payload = asdict(status)
+    payload["age"] = human_age(status.age_seconds)
+    return payload
+
+
+def result_to_dict(result: WorkingMemoryGenerationResult) -> dict[str, Any]:
+    """Convert generation result dataclass to JSON-ready dict."""
+    payload = asdict(result)
+    payload["included_record_ids"] = list(result.included_record_ids)
+    return payload

--- a/src/lerim/working_memory.py
+++ b/src/lerim/working_memory.py
@@ -7,7 +7,7 @@ import shutil
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Protocol
+from typing import Any
 
 from lerim.config.project_scope import match_session_project
 from lerim.config.settings import Config
@@ -17,7 +17,6 @@ WORKING_MEMORY_FILENAME = "WORKING_MEMORY.md"
 WORKING_MEMORY_MANIFEST_FILENAME = "manifest.json"
 WORKING_MEMORY_OPERATION = "working-memory"
 MAX_CANDIDATE_RECORDS = 80
-TARGET_LINE_COUNT = 50
 MAX_LINE_COUNT = 80
 REFERENCE_LINE_LIMIT = 12
 KIND_PRIORITY = {
@@ -102,31 +101,6 @@ class WorkingMemoryStatus:
     current_manifest: str
     latest_run_folder: str | None
     suggested_action: str
-
-
-@dataclass(frozen=True)
-class WorkingMemoryGenerationResult:
-    """Result payload for a refresh attempt."""
-
-    status: str
-    project: str
-    project_id: str
-    generated_at: str | None
-    records_considered: int
-    records_included: int
-    records_changed_since_previous: int
-    included_record_ids: tuple[str, ...]
-    current_file: str
-    current_manifest: str
-    run_folder: str | None
-    skip_reason: str | None = None
-
-
-class WorkingMemorySynthesizer(Protocol):
-    """Port for compressing candidate context records into cited sections."""
-
-    def __call__(self, candidates: list[dict[str, Any]]) -> WorkingMemoryDraft:
-        """Return a cited Working Memory draft for candidate records."""
 
 
 def utc_now_iso() -> str:
@@ -739,11 +713,4 @@ def status_to_dict(status: WorkingMemoryStatus) -> dict[str, Any]:
     """Convert status dataclass to JSON-ready dict."""
     payload = asdict(status)
     payload["age"] = human_age(status.age_seconds)
-    return payload
-
-
-def result_to_dict(result: WorkingMemoryGenerationResult) -> dict[str, Any]:
-    """Convert generation result dataclass to JSON-ready dict."""
-    payload = asdict(result)
-    payload["included_record_ids"] = list(result.included_record_ids)
     return payload

--- a/tests/README.md
+++ b/tests/README.md
@@ -6,7 +6,7 @@ The maintained test surface is DB-first.
 
 What we test:
 
-- unit tests for config, adapters, store, tools, CLI, API, daemon, and runtime
+- unit tests for config, adapters, store, tools, CLI, API, daemon, runtime, and generated Working Memory
 - smoke tests for quick real-LLM extract sanity
 - integration tests for real extract, maintain, semantic ask, cloud sync state, and multi-project scope flows
 - integration tests for runtime orchestration behavior like workspace artifact layout, ask debug trace ordering, and mutation count reporting
@@ -51,6 +51,7 @@ Design rule:
 - `extract` cases are trace-driven
 - `ask` and `maintain` cases are mostly seeded-state-driven
 - scope/runtime/cloud/queue clusters use the smallest real setup that exercises that behavior
+- runtime cases cover generated Working Memory artifact layout, current-copy behavior, skip behavior, and empty-state generation
 
 Some extract pressure cases generate a long trace dynamically instead of checking in a giant fixture. That is intentional. Use a generated trace when the test is about context pressure or pruning, not about exact transcript wording.
 
@@ -85,6 +86,7 @@ Rules:
 - adapter tests cover compact-trace visibility for canonical message fields and structured event messages without keyword heuristics
 - session catalog tests cover queue claim availability, content-hash refresh/change detection, and stable pagination ordering
 - config tests cover provider client lifecycle, provider-specific model settings, fallback-model parsing, strict config parsing, and SDK log-noise filters
+- Working Memory tests cover cwd project resolution, freshness counts, markdown citations, CLI local reads, and artifact writes without live LLM calls
 
 ## Testing rules
 
@@ -106,6 +108,7 @@ The current system is:
 - canonical durable context in `~/.lerim/context.sqlite3`
 - canonical session catalog in `~/.lerim/index/sessions.sqlite3`
 - canonical run artifacts in `~/.lerim/workspace/`
+- generated Working Memory artifacts in `~/.lerim/workspace/current/<project_id>/WORKING_MEMORY.md`
 - local semantic retrieval via ONNX embeddings + `sqlite-vec` + FTS5 + RRF
 - extract tools: `read_trace`, `search_context`, `get_context`, `save_context`, `revise_context`, `note_trace_findings`, `prune_trace_reads`
 - maintain tools: `list_context`, `search_context`, `get_context`, `revise_context`, `archive_context`, `supersede_context`

--- a/tests/fixtures/expectations/runtime/working_memory_refresh_skips_when_records_unchanged.yaml
+++ b/tests/fixtures/expectations/runtime/working_memory_refresh_skips_when_records_unchanged.yaml
@@ -1,0 +1,3 @@
+case: working_memory_refresh_skips_when_records_unchanged
+expected:
+  skip_reason: "no_records_changed_since_previous_generation"

--- a/tests/fixtures/expectations/runtime/working_memory_refresh_writes_dated_and_current_artifacts.yaml
+++ b/tests/fixtures/expectations/runtime/working_memory_refresh_writes_dated_and_current_artifacts.yaml
@@ -1,0 +1,5 @@
+case: working_memory_refresh_writes_dated_and_current_artifacts
+expected:
+  workspace_subdir: "working-memory"
+  records_considered: 2
+  records_included: 2

--- a/tests/fixtures/expectations/runtime/working_memory_refresh_writes_empty_state_without_model_call.yaml
+++ b/tests/fixtures/expectations/runtime/working_memory_refresh_writes_empty_state_without_model_call.yaml
@@ -1,0 +1,7 @@
+case: working_memory_refresh_writes_empty_state_without_model_call
+expected:
+  workspace_subdir: "working-memory"
+  empty_state_must_include:
+    - "No active project context records exist yet."
+    - "lerim sync"
+    - "lerim maintain"

--- a/tests/integration/runtime/test_cases.py
+++ b/tests/integration/runtime/test_cases.py
@@ -10,6 +10,12 @@ from types import SimpleNamespace
 from lerim.agents.ask import AskResult
 from lerim.agents.extract import ExtractionResult
 from lerim.context import ContextStore
+from lerim.working_memory import (
+    MemoryLine,
+    MemorySection,
+    WorkingMemoryDraft,
+    working_memory_paths,
+)
 from tests.integration.runtime.helpers import (
     build_ordered_ask_messages,
     build_runtime_case_context,
@@ -423,3 +429,231 @@ def test_runtime_sync_then_maintain_then_ask_with_real_artifacts(
     assert [item["tool_name"] for item in debug["tool_calls"]] == expectation[
         "ask_tool_call_order"
     ]
+
+
+def test_working_memory_refresh_writes_dated_and_current_artifacts(
+    monkeypatch, live_config, live_repo_root
+):
+    """Working Memory generation should write dated artifacts plus stable current copies."""
+    expectation = load_runtime_expectation(
+        "working_memory_refresh_writes_dated_and_current_artifacts"
+    )["expected"]
+    ctx = build_runtime_case_context(
+        monkeypatch=monkeypatch,
+        live_config=live_config,
+        live_repo_root=live_repo_root,
+    )
+    seed_session_id = "runtime-working-memory-seed"
+    seed_runtime_session(
+        ctx.store,
+        project_id=ctx.project_id,
+        session_id=seed_session_id,
+        repo_root=live_repo_root,
+        source_trace_ref="working-memory-seed",
+    )
+    decision = ctx.store.create_record(
+        project_id=ctx.project_id,
+        session_id=seed_session_id,
+        kind="decision",
+        title="Use generated Working Memory at startup",
+        body="Use generated Working Memory at startup so agents get fast context.",
+        decision="Use generated Working Memory at startup.",
+        why="Startup must stay fast and avoid live synthesis.",
+        change_reason="working_memory_seed_decision",
+    )
+    constraint = ctx.store.create_record(
+        project_id=ctx.project_id,
+        session_id=seed_session_id,
+        kind="constraint",
+        title="Markdown is not canonical memory",
+        body="Markdown Working Memory is a derived view; SQLite remains canonical.",
+        change_reason="working_memory_seed_constraint",
+    )
+    monkeypatch.setattr(
+        "lerim.server.runtime.build_pydantic_model",
+        lambda *args, **kwargs: "fake-model",
+    )
+    monkeypatch.setattr(
+        "lerim.server.runtime.run_working_memory_synthesis",
+        lambda **kwargs: (
+            WorkingMemoryDraft(
+                summary=(
+                    MemoryLine(
+                        "Use generated Working Memory at startup.",
+                        (str(decision["record_id"]),),
+                    ),
+                ),
+                sections=(
+                    MemorySection(
+                        "Startup Context",
+                        (
+                            MemoryLine(
+                                "Keep Markdown derived from SQLite.",
+                                (str(constraint["record_id"]),),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+            build_ordered_ask_messages()[:1],
+        ),
+    )
+
+    result = ctx.runtime.working_memory(
+        repo_root=live_repo_root,
+        project_name="runtime-project",
+        force=True,
+    )
+
+    run_folder = Path(str(result["run_folder"]))
+    paths = working_memory_paths(live_config, ctx.project_id)
+    _assert_run_folder_layout(
+        run_folder,
+        live_config.global_data_dir / "workspace",
+        str(expectation["workspace_subdir"]),
+    )
+    assert result["status"] == "generated"
+    assert result["records_considered"] == int(expectation["records_considered"])
+    assert result["records_included"] == int(expectation["records_included"])
+    assert paths.current_file.is_file()
+    assert paths.current_manifest.is_file()
+    assert (run_folder / "WORKING_MEMORY.md").is_file()
+    assert (run_folder / "agent.log").read_text(encoding="utf-8").strip()
+    manifest = json.loads((run_folder / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["operation"] == "working-memory"
+    assert manifest["status"] == "succeeded"
+    assert manifest["current_file"] == str(paths.current_file)
+    assert sorted(manifest["included_record_ids"]) == sorted(result["included_record_ids"])
+    current_markdown = paths.current_file.read_text(encoding="utf-8")
+    for record_id in result["included_record_ids"]:
+        assert record_id in current_markdown
+    assert "derived view, not the source of truth" in current_markdown
+
+
+def test_working_memory_refresh_skips_when_records_unchanged(
+    monkeypatch, live_config, live_repo_root
+):
+    """A second unchanged refresh should skip before creating a run folder or model call."""
+    expectation = load_runtime_expectation(
+        "working_memory_refresh_skips_when_records_unchanged"
+    )["expected"]
+    ctx = build_runtime_case_context(
+        monkeypatch=monkeypatch,
+        live_config=live_config,
+        live_repo_root=live_repo_root,
+    )
+    seed_session_id = "runtime-working-memory-skip-seed"
+    seed_runtime_session(
+        ctx.store,
+        project_id=ctx.project_id,
+        session_id=seed_session_id,
+        repo_root=live_repo_root,
+        source_trace_ref="working-memory-skip-seed",
+    )
+    decision = ctx.store.create_record(
+        project_id=ctx.project_id,
+        session_id=seed_session_id,
+        kind="decision",
+        title="Skip unchanged Working Memory refresh",
+        body="Skip Working Memory refresh when no records changed.",
+        decision="Skip unchanged Working Memory refresh.",
+        why="Avoid unnecessary model cost.",
+        change_reason="working_memory_skip_seed",
+    )
+    calls = {"synthesis": 0}
+    monkeypatch.setattr(
+        "lerim.server.runtime.build_pydantic_model",
+        lambda *args, **kwargs: "fake-model",
+    )
+
+    def _fake_synthesis(**kwargs):
+        calls["synthesis"] += 1
+        if calls["synthesis"] > 1:
+            raise AssertionError("unchanged refresh should not synthesize")
+        return (
+            WorkingMemoryDraft(
+                summary=(
+                    MemoryLine(
+                        "Skip unchanged Working Memory refresh.",
+                        (str(decision["record_id"]),),
+                    ),
+                ),
+                sections=(),
+            ),
+            build_ordered_ask_messages()[:1],
+        )
+
+    monkeypatch.setattr(
+        "lerim.server.runtime.run_working_memory_synthesis",
+        _fake_synthesis,
+    )
+    first = ctx.runtime.working_memory(
+        repo_root=live_repo_root,
+        project_name="runtime-project",
+        force=True,
+    )
+    operation_dir = Path(str(first["run_folder"])).parent
+    before = sorted(path.name for path in operation_dir.iterdir())
+
+    second = ctx.runtime.working_memory(
+        repo_root=live_repo_root,
+        project_name="runtime-project",
+        force=False,
+    )
+    after = sorted(path.name for path in operation_dir.iterdir())
+
+    assert calls["synthesis"] == 1
+    assert second["status"] == "skipped"
+    assert second["run_folder"] is None
+    assert second["skip_reason"] == expectation["skip_reason"]
+    assert second["records_changed_since_previous"] == 0
+    assert before == after
+
+
+def test_working_memory_refresh_writes_empty_state_without_model_call(
+    monkeypatch, live_config, live_repo_root
+):
+    """Projects with no active records should get an empty-state artifact without synthesis."""
+    expectation = load_runtime_expectation(
+        "working_memory_refresh_writes_empty_state_without_model_call"
+    )["expected"]
+    ctx = build_runtime_case_context(
+        monkeypatch=monkeypatch,
+        live_config=live_config,
+        live_repo_root=live_repo_root,
+    )
+    monkeypatch.setattr(
+        "lerim.server.runtime.build_pydantic_model",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("empty-state refresh should not build a model")
+        ),
+    )
+    monkeypatch.setattr(
+        "lerim.server.runtime.run_working_memory_synthesis",
+        lambda **kwargs: (_ for _ in ()).throw(
+            AssertionError("empty-state refresh should not synthesize")
+        ),
+    )
+
+    result = ctx.runtime.working_memory(
+        repo_root=live_repo_root,
+        project_name="runtime-project",
+        force=True,
+    )
+
+    run_folder = Path(str(result["run_folder"]))
+    paths = working_memory_paths(live_config, ctx.project_id)
+    _assert_run_folder_layout(
+        run_folder,
+        live_config.global_data_dir / "workspace",
+        str(expectation["workspace_subdir"]),
+    )
+    assert result["status"] == "generated"
+    assert result["records_considered"] == 0
+    assert result["records_included"] == 0
+    text = paths.current_file.read_text(encoding="utf-8")
+    for token in expectation["empty_state_must_include"]:
+        assert token in text
+    manifest = json.loads(paths.current_manifest.read_text(encoding="utf-8"))
+    assert manifest["records_considered"] == 0
+    assert manifest["included_record_ids"] == []

--- a/tests/unit/skills/test_skills.py
+++ b/tests/unit/skills/test_skills.py
@@ -48,3 +48,15 @@ class TestSkills(unittest.TestCase):
         end = text.index("---\n", 4) + 4
         body = text[end:].strip()
         self.assertTrue(len(body) > 20, "SKILL.md has no body content")
+
+    def test_skill_documents_working_memory_startup(self) -> None:
+        """Packaged skill should tell agents to read Working Memory first."""
+        text = (SKILLS_DIR / "SKILL.md").read_text(encoding="utf-8")
+        self.assertIn("lerim working-memory show", text)
+        self.assertIn("Working Memory is a generated markdown view", text)
+
+    def test_cli_reference_documents_working_memory(self) -> None:
+        """CLI reference should describe Working Memory commands."""
+        text = (SKILLS_DIR / "cli-reference.md").read_text(encoding="utf-8")
+        self.assertIn("lerim working-memory show", text)
+        self.assertIn("working-memory refresh --force", text)

--- a/tests/unit/test_working_memory.py
+++ b/tests/unit/test_working_memory.py
@@ -1,0 +1,340 @@
+"""Unit tests for generated Working Memory behavior."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from lerim.context import ContextStore, resolve_project_identity
+from lerim.server.runtime import LerimRuntime
+from lerim.working_memory import (
+    MemoryLine,
+    MemorySection,
+    WorkingMemoryDraft,
+    count_changed_records_since,
+    load_candidate_records,
+    render_working_memory_markdown,
+    resolve_working_memory_project,
+    working_memory_paths,
+)
+from tests.helpers import make_config, run_cli, run_cli_json, write_test_config
+
+
+@pytest.fixture
+def mock_embeddings(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+    """Patch embeddings so context writes remain local and deterministic."""
+    provider = MagicMock()
+    provider.embedding_dims = 384
+    provider.model_id = "test-model"
+    provider.embed_document.return_value = [0.1] * 384
+    provider.embed_query.return_value = [0.1] * 384
+    monkeypatch.setattr("lerim.context.store.get_embedding_provider", lambda: provider)
+    return provider
+
+
+def _register_seeded_project(store: ContextStore, repo: Path) -> str:
+    """Register a project plus one source session and return project_id."""
+    identity = resolve_project_identity(repo)
+    store.register_project(identity)
+    store.upsert_session(
+        project_id=identity.project_id,
+        session_id="sess_working_memory",
+        agent_type="test",
+        source_trace_ref="trace.jsonl",
+        repo_path=str(identity.repo_path),
+        cwd=str(identity.repo_path),
+        started_at="2026-04-30T00:00:00+00:00",
+        model_name="test-model",
+        instructions_text=None,
+        prompt_text=None,
+        metadata={},
+    )
+    return identity.project_id
+
+
+def _create_record(
+    store: ContextStore,
+    *,
+    project_id: str,
+    kind: str,
+    title: str,
+) -> dict:
+    """Create one active context record for tests."""
+    return store.create_record(
+        project_id=project_id,
+        session_id="sess_working_memory",
+        kind=kind,
+        title=title,
+        body=f"{title} body.",
+        decision=title if kind == "decision" else None,
+        why="Because it is the project choice." if kind == "decision" else None,
+        user_intent="Understand recent work." if kind == "episode" else None,
+        what_happened="A useful implementation detail was captured."
+        if kind == "episode"
+        else None,
+    )
+
+
+def test_resolve_working_memory_project_uses_most_specific_registered_path(tmp_path):
+    """Cwd project resolution chooses the deepest registered project path."""
+    parent = tmp_path / "parent"
+    child = parent / "child"
+    child.mkdir(parents=True)
+    cfg = replace(
+        make_config(tmp_path / ".lerim"),
+        projects={"parent": str(parent), "child": str(child)},
+    )
+
+    resolved = resolve_working_memory_project(config=cfg, cwd=child / "src")
+
+    assert resolved.name == "child"
+    assert resolved.identity.repo_path == child.resolve()
+
+
+def test_candidate_loading_prioritizes_durable_records(tmp_path, mock_embeddings):
+    """Candidate ordering prefers decisions and constraints before episodes."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    store = ContextStore(tmp_path / "context.sqlite3")
+    project_id = _register_seeded_project(store, repo)
+    episode = _create_record(
+        store,
+        project_id=project_id,
+        kind="episode",
+        title="Debugged the workflow",
+    )
+    store.create_record(
+        project_id=project_id,
+        session_id="sess_working_memory",
+        kind="decision",
+        title="Older generated Working Memory decision",
+        body="Older generated Working Memory decision body.",
+        decision="Older generated Working Memory decision",
+        why="Because older durable choices should follow newer ones.",
+        created_at="2026-04-30T00:00:00+00:00",
+        updated_at="2026-04-30T00:00:00+00:00",
+    )
+    newer_decision = store.create_record(
+        project_id=project_id,
+        session_id="sess_working_memory",
+        kind="decision",
+        title="Newer generated Working Memory decision",
+        body="Newer generated Working Memory decision body.",
+        decision="Newer generated Working Memory decision",
+        why="Because the latest durable choice should lead.",
+        created_at="2026-04-30T01:00:00+00:00",
+        updated_at="2026-04-30T01:00:00+00:00",
+    )
+
+    candidates = load_candidate_records(store, project_id=project_id)
+
+    assert candidates[0]["record_id"] == newer_decision["record_id"]
+    assert candidates[-1]["record_id"] == episode["record_id"]
+
+
+def test_candidate_loading_prefers_newer_records_within_kind(tmp_path, mock_embeddings):
+    """Candidate ordering uses latest updated_at within the same record kind."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    store = ContextStore(tmp_path / "context.sqlite3")
+    project_id = _register_seeded_project(store, repo)
+    old_fact = store.create_record(
+        project_id=project_id,
+        session_id="sess_working_memory",
+        kind="fact",
+        title="Older fact",
+        body="Older fact body.",
+        created_at="2026-04-30T00:00:00+00:00",
+        updated_at="2026-04-30T00:00:00+00:00",
+    )
+    new_fact = store.create_record(
+        project_id=project_id,
+        session_id="sess_working_memory",
+        kind="fact",
+        title="Newer fact",
+        body="Newer fact body.",
+        created_at="2026-04-30T01:00:00+00:00",
+        updated_at="2026-04-30T01:00:00+00:00",
+    )
+
+    candidates = load_candidate_records(store, project_id=project_id)
+
+    fact_ids = [row["record_id"] for row in candidates if row["kind"] == "fact"]
+    assert fact_ids[:2] == [new_fact["record_id"], old_fact["record_id"]]
+
+
+def test_rendered_markdown_contains_freshness_and_citations(tmp_path):
+    """Renderer includes freshness fields and record citations."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    project = resolve_working_memory_project(
+        config=replace(make_config(tmp_path / ".lerim"), projects={"repo": str(repo)}),
+        cwd=repo,
+    )
+    draft = WorkingMemoryDraft(
+        summary=(MemoryLine("Use generated Working Memory", ("rec_123",)),),
+        sections=(
+            MemorySection(
+                "Decisions",
+                (MemoryLine("Keep SQLite canonical", ("rec_456",)),),
+            ),
+        ),
+    )
+
+    markdown = render_working_memory_markdown(
+        project=project,
+        generated_at="2026-04-30T00:00:00+00:00",
+        records_included=2,
+        changed_since_generation=3,
+        draft=draft,
+    )
+
+    assert "Records changed since generation: 3" in markdown
+    assert "Use generated Working Memory [rec_123]" in markdown
+    assert "Keep SQLite canonical [rec_456]" in markdown
+
+
+def test_changed_record_count_uses_versions_since_baseline(tmp_path, mock_embeddings):
+    """Freshness count tracks created records after the generation baseline."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    store = ContextStore(tmp_path / "context.sqlite3")
+    project_id = _register_seeded_project(store, repo)
+    baseline = "2026-04-30T00:00:00+00:00"
+    created = _create_record(
+        store,
+        project_id=project_id,
+        kind="decision",
+        title="Newer decision",
+    )
+
+    count = count_changed_records_since(store, project_id=project_id, since=baseline)
+
+    assert count == 1
+    assert created["record_id"]
+
+
+def test_runtime_refresh_writes_dated_and_current_artifacts(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+    mock_embeddings,
+):
+    """Runtime refresh writes run-local and stable current artifacts."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    cfg = replace(make_config(tmp_path / ".lerim"), projects={"repo": str(repo)})
+    store = ContextStore(cfg.context_db_path)
+    project_id = _register_seeded_project(store, repo)
+    record = _create_record(
+        store,
+        project_id=project_id,
+        kind="decision",
+        title="Generate cited startup context",
+    )
+    monkeypatch.setattr(
+        "lerim.config.providers.validate_provider_for_role",
+        lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(
+        "lerim.server.runtime.build_pydantic_model",
+        lambda *args, **kwargs: object(),
+    )
+    monkeypatch.setattr(
+        "lerim.server.runtime.run_working_memory_synthesis",
+        lambda **_kwargs: (
+            WorkingMemoryDraft(
+                summary=(
+                    MemoryLine(
+                        "Generate cited startup context",
+                        (record["record_id"],),
+                    ),
+                ),
+                sections=(),
+            ),
+            [],
+        ),
+    )
+
+    runtime = LerimRuntime(default_cwd=str(repo), config=cfg)
+    result = runtime.working_memory(repo_root=repo, project_name="repo", force=True)
+    paths = working_memory_paths(cfg, project_id)
+
+    assert result["status"] == "generated"
+    assert paths.current_file.is_file()
+    assert Path(result["run_folder"], "WORKING_MEMORY.md").is_file()
+    assert record["record_id"] in paths.current_file.read_text(encoding="utf-8")
+
+
+def test_cli_show_reads_existing_current_artifact(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """CLI show prints the current file without invoking refresh."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    config_path = write_test_config(tmp_path, projects={"repo": str(repo)})
+    monkeypatch.setenv("LERIM_CONFIG", str(config_path))
+    from lerim.config.settings import reload_config
+
+    cfg = reload_config()
+    project_id = resolve_project_identity(repo).project_id
+    paths = working_memory_paths(cfg, project_id)
+    paths.current_dir.mkdir(parents=True)
+    paths.current_file.write_text("# Working Memory\n\nhello\n", encoding="utf-8")
+    monkeypatch.chdir(repo)
+    monkeypatch.setattr(
+        "lerim.server.cli.run_working_memory_for_project",
+        lambda **_kwargs: pytest.fail("show must not refresh"),
+    )
+
+    code, output = run_cli(["working-memory", "show"])
+
+    assert code == 0
+    assert "hello" in output
+
+
+def test_cli_status_json_reports_changed_records(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+    mock_embeddings,
+) -> None:
+    """CLI status JSON exposes freshness metadata for scripts."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    config_path = write_test_config(tmp_path, projects={"repo": str(repo)})
+    monkeypatch.setenv("LERIM_CONFIG", str(config_path))
+    from lerim.config.settings import reload_config
+
+    cfg = reload_config()
+    store = ContextStore(cfg.context_db_path)
+    project_id = _register_seeded_project(store, repo)
+    paths = working_memory_paths(cfg, project_id)
+    paths.current_dir.mkdir(parents=True)
+    paths.current_file.write_text("# Working Memory\n", encoding="utf-8")
+    paths.current_manifest.write_text(
+        json.dumps(
+            {
+                "generated_at": "2026-04-30T00:00:00+00:00",
+                "records_included": 0,
+                "run_folder": str(tmp_path / "run"),
+            }
+        ),
+        encoding="utf-8",
+    )
+    _create_record(
+        store,
+        project_id=project_id,
+        kind="decision",
+        title="New startup context choice",
+    )
+    monkeypatch.chdir(repo)
+
+    code, payload = run_cli_json(["working-memory", "status", "--json"])
+
+    assert code == 0
+    assert payload["availability"] == "stale"
+    assert payload["records_changed_since_generation"] == 1

--- a/tests/unit/test_working_memory.py
+++ b/tests/unit/test_working_memory.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from dataclasses import replace
+from dataclasses import fields, replace
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -19,6 +19,7 @@ from lerim.working_memory import (
     load_candidate_records,
     render_working_memory_markdown,
     resolve_working_memory_project,
+    working_memory_status,
     working_memory_paths,
 )
 from tests.helpers import make_config, run_cli, run_cli_json, write_test_config
@@ -77,6 +78,13 @@ def _create_record(
         if kind == "episode"
         else None,
     )
+
+
+def _markdown_heading_index(markdown: str, heading: str) -> int:
+    """Return the index of a markdown heading, failing clearly when absent."""
+    marker = f"\n{heading}\n"
+    assert marker in markdown
+    return markdown.index(marker)
 
 
 def test_resolve_working_memory_project_uses_most_specific_registered_path(tmp_path):
@@ -167,6 +175,96 @@ def test_candidate_loading_prefers_newer_records_within_kind(tmp_path, mock_embe
     assert fact_ids[:2] == [new_fact["record_id"], old_fact["record_id"]]
 
 
+def test_working_memory_draft_has_fixed_sections_with_sections_fallback():
+    """Draft contract exposes fixed sections plus legacy section fallback."""
+    assert [field.name for field in fields(WorkingMemoryDraft)] == [
+        "summary",
+        "start_here",
+        "current_handoff",
+        "decisions",
+        "constraints_preferences",
+        "project_facts",
+        "open_risks",
+        "follow_up_queries",
+        "sections",
+    ]
+
+
+def test_rendered_markdown_uses_fixed_section_order_and_sections_fallback(tmp_path):
+    """Renderer emits fixed sections in order before legacy fallback sections."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    project = resolve_working_memory_project(
+        config=replace(make_config(tmp_path / ".lerim"), projects={"repo": str(repo)}),
+        cwd=repo,
+    )
+    draft = WorkingMemoryDraft(
+        summary=(MemoryLine("Summary line", ("rec_summary",)),),
+        start_here=(MemoryLine("Use the package directory", ("rec_start",)),),
+        current_handoff=(MemoryLine("Resume the handoff", ("rec_handoff",)),),
+        decisions=(MemoryLine("Keep SQLite canonical", ("rec_decision",)),),
+        constraints_preferences=(
+            MemoryLine("Respect the no-fallback rule", ("rec_constraint",)),
+        ),
+        project_facts=(MemoryLine("CLI code lives under src", ("rec_fact",)),),
+        open_risks=(MemoryLine("Review queue still has risk", ("rec_risk",)),),
+        follow_up_queries=(MemoryLine("Query the newest records", ("rec_query",)),),
+        sections=(
+            MemorySection(
+                "Legacy Fallback",
+                (MemoryLine("Render older agent sections last", ("rec_legacy",)),),
+            ),
+        ),
+    )
+    candidate_records = [
+        {
+            "record_id": record_id,
+            "kind": kind,
+            "title": title,
+            "updated_at": "2026-04-30T00:00:00+00:00",
+        }
+        for record_id, kind, title in (
+            ("rec_summary", "decision", "Summary line"),
+            ("rec_start", "reference", "Use the package directory"),
+            ("rec_handoff", "episode", "Resume the handoff"),
+            ("rec_decision", "decision", "Keep SQLite canonical"),
+            ("rec_constraint", "constraint", "Respect the no-fallback rule"),
+            ("rec_fact", "fact", "CLI code lives under src"),
+            ("rec_risk", "episode", "Review queue still has risk"),
+            ("rec_query", "reference", "Query the newest records"),
+            ("rec_legacy", "episode", "Render older agent sections last"),
+        )
+    ]
+
+    markdown = render_working_memory_markdown(
+        project=project,
+        generated_at="2026-04-30T00:00:00+00:00",
+        previous_generated_at=None,
+        generation_trigger="manual",
+        records_considered=len(candidate_records),
+        records_included=len(candidate_records),
+        db_records_changed_since_previous=0,
+        draft=draft,
+        candidate_records=candidate_records,
+    )
+
+    headings = [
+        "## Start Here",
+        "## Summary",
+        "## Current Handoff",
+        "## Decisions",
+        "## Constraints & Preferences",
+        "## Project Facts",
+        "## Open Risks / Review Queue",
+        "## Follow-up Queries",
+        "## Legacy Fallback",
+        "## Sources",
+    ]
+    positions = [_markdown_heading_index(markdown, heading) for heading in headings]
+    assert positions == sorted(positions)
+    assert "Render older agent sections last [rec_legacy]" in markdown
+
+
 def test_rendered_markdown_contains_freshness_and_citations(tmp_path):
     """Renderer includes freshness fields and record citations."""
     repo = tmp_path / "repo"
@@ -188,14 +286,135 @@ def test_rendered_markdown_contains_freshness_and_citations(tmp_path):
     markdown = render_working_memory_markdown(
         project=project,
         generated_at="2026-04-30T00:00:00+00:00",
+        previous_generated_at="2026-04-29T00:00:00+00:00",
+        generation_trigger="manual",
+        records_considered=4,
         records_included=2,
-        changed_since_generation=3,
+        db_records_changed_since_previous=3,
         draft=draft,
+        candidate_records=[
+            {
+                "record_id": "rec_123",
+                "kind": "decision",
+                "title": "Use generated Working Memory",
+                "updated_at": "2026-04-30T00:00:00+00:00",
+                "source_session_id": "sess_1",
+            },
+            {
+                "record_id": "rec_456",
+                "kind": "constraint",
+                "title": "Keep SQLite canonical",
+                "updated_at": "2026-04-30T00:00:00+00:00",
+                "source_session_id": "sess_2",
+            },
+        ],
     )
 
-    assert "Records changed since generation: 3" in markdown
+    assert "Records considered: 4" in markdown
+    assert "Previous generation: `2026-04-29T00:00:00+00:00`" in markdown
+    assert "Generation trigger: `manual`" in markdown
+    assert "Records cited: 2" in markdown
+    assert "DB records changed before this generation: 3" in markdown
     assert "Use generated Working Memory [rec_123]" in markdown
     assert "Keep SQLite canonical [rec_456]" in markdown
+    assert "`rec_123` (decision" in markdown
+    assert "source_session: `sess_1`" in markdown
+
+
+def test_rendered_markdown_preserves_sources_when_body_is_long(tmp_path):
+    """Renderer keeps source references even when the body must be truncated."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    project = resolve_working_memory_project(
+        config=replace(make_config(tmp_path / ".lerim"), projects={"repo": str(repo)}),
+        cwd=repo,
+    )
+    record_ids = tuple(f"rec_{idx:03d}" for idx in range(20))
+    draft = WorkingMemoryDraft(
+        summary=(MemoryLine("Summary item", (record_ids[0],)),),
+        sections=tuple(
+            MemorySection(
+                f"Long Section {section_idx}",
+                tuple(
+                    MemoryLine(
+                        f"Long detail {section_idx}-{idx}",
+                        (record_ids[idx % len(record_ids)],),
+                    )
+                    for idx in range(14)
+                ),
+            )
+            for section_idx in range(8)
+        ),
+    )
+    candidates = [
+        {
+            "record_id": record_id,
+            "kind": "decision",
+            "title": f"Decision {idx}",
+            "updated_at": "2026-04-30T00:00:00+00:00",
+        }
+        for idx, record_id in enumerate(record_ids)
+    ]
+
+    markdown = render_working_memory_markdown(
+        project=project,
+        generated_at="2026-04-30T00:00:00+00:00",
+        previous_generated_at=None,
+        generation_trigger="manual",
+        records_considered=len(candidates),
+        records_included=len(record_ids),
+        db_records_changed_since_previous=0,
+        draft=draft,
+        candidate_records=candidates,
+    )
+
+    assert "## Sources" in markdown
+    assert "`rec_000`" in markdown
+    assert "Body truncated for startup size" in markdown
+    assert "## Project Facts\n\n\n> Body truncated" not in markdown
+
+
+def test_rendered_markdown_dedupes_and_skips_empty_cleaned_lines(tmp_path):
+    """Renderer removes accidental inline IDs and skips duplicate/empty bullets."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    project = resolve_working_memory_project(
+        config=replace(make_config(tmp_path / ".lerim"), projects={"repo": str(repo)}),
+        cwd=repo,
+    )
+    draft = WorkingMemoryDraft(
+        summary=(
+            MemoryLine("Use SQLite rec_abc", ("rec_abc",)),
+            MemoryLine("Use SQLite", ("rec_abc",)),
+            MemoryLine("rec_abc", ("rec_abc",)),
+        ),
+        decisions=(
+            MemoryLine("Use SQLite", ("rec_abc",)),
+            MemoryLine("", ("rec_abc",)),
+        ),
+    )
+
+    markdown = render_working_memory_markdown(
+        project=project,
+        generated_at="2026-04-30T00:00:00+00:00",
+        previous_generated_at=None,
+        generation_trigger="manual",
+        records_considered=1,
+        records_included=1,
+        db_records_changed_since_previous=0,
+        draft=draft,
+        candidate_records=[
+            {
+                "record_id": "rec_abc",
+                "kind": "decision",
+                "title": "Use SQLite",
+                "updated_at": "2026-04-30T00:00:00+00:00",
+            }
+        ],
+    )
+
+    assert markdown.count("Use SQLite [rec_abc]") == 1
+    assert "- [rec_abc]" not in markdown
 
 
 def test_changed_record_count_uses_versions_since_baseline(tmp_path, mock_embeddings):
@@ -272,8 +491,9 @@ def test_runtime_refresh_writes_dated_and_current_artifacts(
 def test_cli_show_reads_existing_current_artifact(
     tmp_path,
     monkeypatch: pytest.MonkeyPatch,
+    mock_embeddings,
 ) -> None:
-    """CLI show prints the current file without invoking refresh."""
+    """CLI show prints live freshness before the current file without refresh."""
     repo = tmp_path / "repo"
     repo.mkdir()
     config_path = write_test_config(tmp_path, projects={"repo": str(repo)})
@@ -281,10 +501,31 @@ def test_cli_show_reads_existing_current_artifact(
     from lerim.config.settings import reload_config
 
     cfg = reload_config()
-    project_id = resolve_project_identity(repo).project_id
+    store = ContextStore(cfg.context_db_path)
+    project_id = _register_seeded_project(store, repo)
     paths = working_memory_paths(cfg, project_id)
     paths.current_dir.mkdir(parents=True)
     paths.current_file.write_text("# Working Memory\n\nhello\n", encoding="utf-8")
+    paths.current_manifest.write_text(
+        json.dumps(
+            {
+                "generated_at": "2026-04-30T00:00:00+00:00",
+                "records_included": 0,
+            }
+        ),
+        encoding="utf-8",
+    )
+    store.create_record(
+        project_id=project_id,
+        session_id="sess_working_memory",
+        kind="decision",
+        title="Fresh live context",
+        body="Fresh live context body.",
+        decision="Fresh live context",
+        why="Because show should report live freshness.",
+        created_at="2026-04-30T01:00:00+00:00",
+        updated_at="2026-04-30T01:00:00+00:00",
+    )
     monkeypatch.chdir(repo)
     monkeypatch.setattr(
         "lerim.server.cli.run_working_memory_for_project",
@@ -294,6 +535,10 @@ def test_cli_show_reads_existing_current_artifact(
     code, output = run_cli(["working-memory", "show"])
 
     assert code == 0
+    assert "Working Memory Live Status:" in output
+    assert "- availability: stale" in output
+    assert "- db_records_changed_since_generation: 1" in output
+    assert "Refresh if newest persisted DB context matters." in output
     assert "hello" in output
 
 
@@ -338,3 +583,30 @@ def test_cli_status_json_reports_changed_records(
     assert code == 0
     assert payload["availability"] == "stale"
     assert payload["records_changed_since_generation"] == 1
+
+
+def test_status_reports_error_when_manifest_missing(
+    tmp_path,
+    mock_embeddings,
+) -> None:
+    """A current markdown without manifest is an error, not stale."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    cfg = replace(make_config(tmp_path / ".lerim"), projects={"repo": str(repo)})
+    store = ContextStore(cfg.context_db_path)
+    project_id = _register_seeded_project(store, repo)
+    paths = working_memory_paths(cfg, project_id)
+    paths.current_dir.mkdir(parents=True)
+    paths.current_file.write_text("# Working Memory\n", encoding="utf-8")
+    _create_record(
+        store,
+        project_id=project_id,
+        kind="decision",
+        title="New record without manifest",
+    )
+    project = resolve_working_memory_project(config=cfg, cwd=repo)
+
+    status = working_memory_status(config=cfg, store=store, project=project)
+
+    assert status.availability == "error"
+    assert status.suggested_action == "Run `lerim working-memory refresh --force`."

--- a/uv.lock
+++ b/uv.lock
@@ -2645,7 +2645,7 @@ wheels = [
 
 [[package]]
 name = "lerim"
-version = "0.1.81"
+version = "0.1.82"
 source = { editable = "." }
 dependencies = [
     { name = "eval-type-backport", marker = "python_full_version < '3.13'" },

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -46,6 +46,11 @@ git_branch  # noqa
 model_config  # noqa
 last_context_tokens  # noqa
 metrics_version  # noqa
+records_changed_since_generation  # noqa
+latest_run_folder  # noqa
+suggested_action  # noqa
+records_changed_since_previous  # noqa
+skip_reason  # noqa
 
 # Pydantic validators and Agent validators registered by decorators
 validate_level  # noqa


### PR DESCRIPTION
## Summary
- add generated `WORKING_MEMORY.md` artifacts for fast coding-agent startup context
- add CLI/runtime/daemon support for working-memory `status`, `show`, `path`, and `refresh`
- document the workflow and update the Lerim skill guidance for agents
- bump package version to `0.1.82`

## Validation
- `uv run pytest tests/unit/test_working_memory.py tests/unit/server/test_runtime.py tests/unit/server/test_daemon_functions.py tests/unit/server/test_cli.py tests/unit/skills/test_skills.py -q`
- `uv run ruff check src/lerim/working_memory.py vulture_whitelist.py`
- `uv run vulture`
- pre-push hooks: ruff, vulture

## Release
- intended release tag: `v0.1.82`
