### PR TITLE
Add agent flowcharts to CLI docs

### DIFF
--- a/docs/cli/ask.md
+++ b/docs/cli/ask.md
@@ -13,4 +13,30 @@ lerim ask "How is caching handled?" --scope project --project lerim-cli
 
 `ask` uses hybrid retrieval against the global context database and then fetches the full records needed for the answer.
 
+```mermaid
+flowchart TD
+    A["User runs lerim ask"] --> B["Ask agent receives question and project scope"]
+
+    B --> C["Prompt goal: answer only from retrieved Lerim records"]
+    C --> D{"What kind of question is this?"}
+
+    D -- "count, latest, date, current state" --> E["Use exact tools: count_context or list_context"]
+    D -- "topic, rationale, explanation" --> F["Use search_context for hybrid semantic + lexical retrieval"]
+    D -- "mixed question" --> G["Use exact filtering first, then search or inspect within that set"]
+
+    E --> H{"Is the returned evidence enough?"}
+    F --> H
+    G --> H
+
+    H -- "needs full source" --> I["Use get_context to fetch full records and versions"]
+    H -- "enough" --> J["Synthesize answer"]
+
+    I --> K{"Do records support the answer?"}
+    K -- "yes" --> J
+    K -- "no" --> L["Say the context does not contain enough evidence"]
+
+    J --> M["Return answer, scope, projects used, optional debug trace"]
+    L --> M
+```
+
 Use `--scope project` when you want one project only.

--- a/docs/cli/maintain.md
+++ b/docs/cli/maintain.md
@@ -19,3 +19,32 @@ lerim maintain --dry-run
 - supersede outdated records
 
 It works on the database.
+
+## Flow
+
+```mermaid
+flowchart TD
+    A["Trigger: lerim maintain or daemon"] --> B["Maintain agent receives project context task"]
+
+    B --> C["Prompt goal: keep memory useful, current, compact, and non-duplicative"]
+    C --> D["Agent lists or searches active records"]
+    D --> E["Agent fetches full records before any mutation"]
+
+    E --> F{"What problem is found?"}
+    F -- "duplicate or outdated truth" --> G["Use supersede_context to point old memory to newer truth"]
+    F -- "verbose, weak, or report-like" --> H["Use revise_context to rewrite into reusable present-tense memory"]
+    F -- "junk, obsolete, or low-value episode" --> I["Use archive_context"]
+    F -- "still useful" --> J["Leave unchanged"]
+
+    G --> K["SQLite context DB + record_versions"]
+    H --> K
+    I --> K
+    J --> L{"More records to inspect?"}
+    K --> L
+
+    L -- "yes" --> D
+    L -- "no" --> M["Maintain summary and artifacts"]
+    M --> N{"Any records changed?"}
+    N -- "yes" --> O["Refresh Working Memory for project"]
+    N -- "no" --> P["Finish"]
+```

--- a/docs/cli/sync.md
+++ b/docs/cli/sync.md
@@ -19,6 +19,36 @@ lerim sync --agent claude,codex
 - runs extraction
 - writes records into `~/.lerim/context.sqlite3`
 
+## Flow
+
+```mermaid
+flowchart TD
+    A["Trigger: lerim sync or daemon"] --> B["Discover and queue changed sessions"]
+    B --> C["Extract agent receives one session trace"]
+
+    C --> D["Prompt goal: turn this session into durable project memory"]
+    D --> E["Agent reads trace chunks with read_trace"]
+    E --> F{"Has the agent read enough of the trace?"}
+    F -- "no" --> E
+    F -- "yes" --> G["Agent identifies candidate memories: episode, decisions, preferences, constraints, facts, references"]
+
+    G --> H{"Could this update or duplicate existing memory?"}
+    H -- "yes" --> I["Use search_context/get_context to inspect existing records"]
+    H -- "no" --> J["Prepare new records"]
+
+    I --> K{"Existing record should change?"}
+    K -- "revise" --> L["Use revise_context on fetched record"]
+    K -- "new memory" --> J
+    K -- "no durable value" --> M["Do not write"]
+
+    J --> N["Use save_context for supported durable records"]
+    L --> O["SQLite context DB + record_versions"]
+    N --> O
+    M --> P["Completion summary"]
+    O --> P
+    P --> Q["Sync artifacts: manifest, agent log, trace"]
+```
+
 ## Notes
 
 - `--no-extract` only indexes and queues work

--- a/docs/cli/working-memory.md
+++ b/docs/cli/working-memory.md
@@ -83,18 +83,26 @@ Dated run artifacts:
 
 ```mermaid
 flowchart TD
-    A["lerim working-memory refresh"] --> B["Resolve registered project"]
-    B --> C["Count DB records changed since current manifest generated_at"]
-    C --> D{"Unchanged and current file exists?"}
-    D -- "yes" --> E["Skip without model call"]
-    D -- "no" --> F["Load active candidate records from SQLite"]
-    F --> G{"Candidates exist?"}
-    G -- "no" --> H["Render empty-state Markdown"]
-    G -- "yes" --> I["Run Working Memory synthesis agent"]
-    I --> J["Validate cited record IDs and fixed sections"]
-    H --> K["Write dated run artifacts"]
-    J --> K
-    K --> L["Copy latest markdown and manifest to workspace/current"]
+    A["Trigger: daily daemon, after maintain, or manual refresh"] --> B["Resolve project and check current manifest"]
+    B --> C{"New DB records or --force?"}
+
+    C -- "no" --> D["Skip generation"]
+    C -- "yes" --> E["Select candidate records from SQLite"]
+    E --> F["Working Memory agent receives compact candidate set"]
+
+    F --> G["Prompt goal: create fast startup memory from candidates only"]
+    G --> H["Agent ranks what matters for starting work: current handoff, decisions, preferences, facts, risks"]
+    H --> I["Agent writes fixed sections with cited record IDs"]
+
+    I --> J{"Every line cites an allowed source record?"}
+    J -- "no" --> K["Validation fails; retry or error"]
+    J -- "yes" --> L["Render WORKING_MEMORY.md"]
+
+    L --> M["Write dated artifact"]
+    M --> N["Update workspace/current/<project_id>/WORKING_MEMORY.md"]
+
+    O["Agent startup"] --> P["lerim working-memory show"]
+    P --> Q["Fast read of generated memory plus live freshness status"]
 ```
 
 ## Automation


### PR DESCRIPTION
## Summary
- add Mermaid flowcharts for `sync`, `maintain`, and `ask` CLI docs
- replace the `working-memory` generation diagram with the agent-oriented flow

## Validation
- `uv run --extra docs mkdocs build --strict`
- pre-push hooks: ruff, vulture
