### PR TITLE
Add custom trace folder projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1] - 2026-05-16
+
+### Added
+- Added custom trace-folder projects with `lerim project add <path> --type custom`.
+- Added direct custom JSONL session discovery with `agent_type=custom`, without platform adapters or compaction.
+- Added custom-agent integration docs with a pasteable cleaner prompt for generating customer-owned trace cleaning scripts.
+- Added per-agent architecture docs with Mermaid flowcharts generated from the compiled LangGraph graphs.
+- Added integration coverage that registers a custom project, writes synthetic traces, runs ingest, and verifies custom sessions/jobs use the original clean trace files.
+
+### Changed
+- Updated README, docs, bundled skill text, and configuration reference around the broader context-compiler positioning and custom-agent trace flow.
+- Extended project config/API/CLI payloads with `supported` and `custom` source types while preserving existing project defaults.
+
 ## [0.2.0] - 2026-05-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -55,11 +55,14 @@ Without a durable context layer:
 
 Lerim fixes that by turning raw traces into reusable context records and making them queryable from agent tools and product workflows.
 
-The current package provides the trace-to-context foundation and supported source adapters. For customer deployments, Lerim can be adapted around the business traces that matter: support handoffs, operations incidents, research workflows, revenue processes, security reviews, and internal automation logs.
+The current package provides the trace-to-context foundation, supported source
+adapters, and custom clean-trace folders for business workflows such as support
+handoffs, operations incidents, research workflows, revenue processes, security
+reviews, and internal automation logs.
 
 ## Key Capabilities
 
-- Trace-to-context extraction. `ingest` reads supported traces, extracts reusable signal, and can archive routine runs without creating noisy durable records.
+- Trace-to-context extraction. `ingest` reads supported sources and custom clean-trace folders, extracts reusable signal, and can archive routine runs without creating noisy durable records.
 - Shared context across agents. What one agent learns can become useful context for a different agent or workflow later.
 - Context curation. Lerim consolidates overlap, archives weak records, and keeps the context layer compact.
 - Query and startup context. Agents can ask questions against accumulated context or start from a compact context brief.
@@ -80,30 +83,30 @@ The current package provides the trace-to-context foundation and supported sourc
 Built-in `connect` adapters monitor the supported sources available today:
 Claude Code, Codex CLI, Cursor, and OpenCode.
 
-For another agent or business workflow, use explicit trace import:
+For another agent or business workflow, create a folder of already-clean Lerim
+canonical JSONL traces and register it as a custom project:
 
 ```bash
-lerim trace import ./support-agent-run.jsonl \
-  --source-name support-bot \
-  --source-profile support \
-  --scope-type domain \
-  --scope support
+python clean_to_lerim_jsonl.py \
+  --input ./raw-support-agent-traces \
+  --output ~/lerim-traces/support-clean
+
+lerim project add ~/lerim-traces/support-clean --type custom
+lerim ingest --agent custom
 ```
 
-The trace can be JSON, JSONL, or plain text. Lerim normalizes it into the compact
-trace shape, stores a canonical copy under the Lerim workspace, registers the
-selected scope, and runs ingestion into the shared context store.
+Each `.jsonl` file is one completed source session. Each line must be a
+canonical user or assistant event:
 
-Today, the custom-agent path expects the user or customer system to produce the
-trace file and call `lerim trace import` after a run. For a customer deployment,
-the adapter layer can automate that step around the customer's agent runtime,
-ticket system, browser workflow, or internal automation logs.
+```json
+{"type":"user","message":{"role":"user","content":"Customer asked for renewal approval."},"timestamp":"2026-05-16T09:00:00Z"}
+{"type":"assistant","message":{"role":"assistant","content":"Agent found approval is required above EUR 500."},"timestamp":"2026-05-16T09:02:00Z"}
+```
 
-Customers can also run their own exporter, cleaner, or redaction step before
-import. That is the recommended path when traces contain source-specific noise,
-large tool payloads, secrets, regulated data, or customer-specific retention
-rules. Lerim filters for durable signal during ingestion, but it should not be
-used as the only privacy or compliance sanitizer for arbitrary traces.
+Custom mode has no Lerim adapter and no compaction step. The user or customer
+owns the exporter, cleaner, redaction, and retention boundary before files enter
+the custom folder. See the custom trace folder guide for the pasteable prompt
+that helps a coding agent generate that cleaner.
 
 ## Quick Start
 
@@ -351,7 +354,7 @@ Contributions are welcome.
 
 Good starting points include:
 
-- trace-source adapters and generic import
+- trace-source adapters and custom trace-folder examples
 - extraction quality
 - context curation quality
 - docs and demo examples

--- a/docs/agents/context-answerer.md
+++ b/docs/agents/context-answerer.md
@@ -1,0 +1,45 @@
+# Context Answerer Agent
+
+The context answerer retrieves stored context and synthesizes evidence-backed
+answers for agents and users.
+
+The graph below is generated from the compiled LangGraph runtime.
+
+```mermaid
+---
+config:
+  flowchart:
+    curve: linear
+---
+graph TD;
+    __start__([<p>__start__</p>]):::first
+    plan_retrieval(plan_retrieval)
+    execute_retrieval(execute_retrieval)
+    synthesize_answer(synthesize_answer)
+    __end__([<p>__end__</p>]):::last
+    __start__ --> plan_retrieval;
+    execute_retrieval --> synthesize_answer;
+    plan_retrieval --> execute_retrieval;
+    synthesize_answer --> __end__;
+    classDef default fill:#f2f0ff,line-height:1.2
+    classDef first fill-opacity:0
+    classDef last fill:#bfb6fc
+```
+
+## Inputs
+
+- user or agent question
+- allowed project ids
+- retrieval budget from config
+- context-store records and search indexes
+
+## Flow
+
+1. `plan_retrieval` chooses the context reads needed for the question.
+2. `execute_retrieval` runs the bounded deterministic store reads.
+3. `synthesize_answer` writes the final answer from retrieved evidence.
+
+## Output
+
+The answer includes cited context when evidence exists. When the store cannot
+support a claim, the answer should say that instead of inventing context.

--- a/docs/agents/context-brief.md
+++ b/docs/agents/context-brief.md
@@ -1,0 +1,44 @@
+# Context Brief Agent
+
+The context brief agent compiles startup context from stored records so a new
+agent session can begin with compact project memory.
+
+The graph below is generated from the compiled LangGraph runtime.
+
+```mermaid
+---
+config:
+  flowchart:
+    curve: linear
+---
+graph TD;
+    __start__([<p>__start__</p>]):::first
+    prepare_candidates(prepare_candidates)
+    compile_brief(compile_brief)
+    build_draft(build_draft)
+    __end__([<p>__end__</p>]):::last
+    __start__ --> prepare_candidates;
+    compile_brief --> build_draft;
+    prepare_candidates --> compile_brief;
+    build_draft --> __end__;
+    classDef default fill:#f2f0ff,line-height:1.2
+    classDef first fill-opacity:0
+    classDef last fill:#bfb6fc
+```
+
+## Inputs
+
+- recent and important context records for one project
+- freshness metadata
+- existing brief state
+
+## Flow
+
+1. `prepare_candidates` shapes context records for the compiler.
+2. `compile_brief` selects and organizes startup context.
+3. `build_draft` writes the generated markdown artifact.
+
+## Output
+
+The generated `CONTEXT_BRIEF.md` is a derived startup artifact. It is not the
+durable context store.

--- a/docs/agents/context-curator.md
+++ b/docs/agents/context-curator.md
@@ -1,0 +1,52 @@
+# Context Curator Agent
+
+The context curator is the cold path. It keeps existing records compact,
+non-duplicative, and current.
+
+The graph below is generated from the compiled LangGraph runtime.
+
+```mermaid
+---
+config:
+  flowchart:
+    curve: linear
+---
+graph TD;
+    __start__([<p>__start__</p>]):::first
+    load_inventory(load_inventory)
+    build_clusters(build_clusters)
+    review_clusters(review_clusters)
+    review_health(review_health)
+    apply_actions(apply_actions)
+    __end__([<p>__end__</p>]):::last
+    __start__ --> load_inventory;
+    build_clusters --> review_clusters;
+    load_inventory --> build_clusters;
+    review_clusters --> review_health;
+    review_health --> apply_actions;
+    apply_actions --> __end__;
+    classDef default fill:#f2f0ff,line-height:1.2
+    classDef first fill-opacity:0
+    classDef last fill:#bfb6fc
+```
+
+## Inputs
+
+- active records for one project
+- semantic-neighbor candidates
+- curation budget from config
+
+## Flow
+
+1. `load_inventory` loads active records.
+2. `build_clusters` groups likely-neighbor records.
+3. `review_clusters` decides whether records duplicate, replace, or complement
+   each other.
+4. `review_health` reviews remaining records for routine episodes, stale
+   context, or verbose recap style.
+5. `apply_actions` applies validated archive, revise, and supersede actions.
+
+## Output
+
+The context store is updated in place. The curator prefers fewer stronger
+records over many overlapping or routine records.

--- a/docs/agents/trace-ingestion.md
+++ b/docs/agents/trace-ingestion.md
@@ -1,0 +1,59 @@
+# Trace Ingestion Agent
+
+Trace ingestion is the hot path. It turns one indexed source session into a
+small episode record plus zero or more durable context records.
+
+The graph below is generated from the compiled LangGraph runtime.
+
+```mermaid
+---
+config:
+  flowchart:
+    curve: linear
+---
+graph TD;
+    __start__([<p>__start__</p>]):::first
+    resolve_scope(resolve_scope)
+    read_window(read_window)
+    scan_window(scan_window)
+    filter_signals(filter_signals)
+    synthesize_records(synthesize_records)
+    review_records(review_records)
+    persist_records(persist_records)
+    __end__([<p>__end__</p>]):::last
+    __start__ --> resolve_scope;
+    filter_signals --> synthesize_records;
+    read_window --> scan_window;
+    resolve_scope --> read_window;
+    review_records --> persist_records;
+    scan_window -.-> filter_signals;
+    scan_window -.-> read_window;
+    synthesize_records --> review_records;
+    persist_records --> __end__;
+    classDef default fill:#f2f0ff,line-height:1.2
+    classDef first fill-opacity:0
+    classDef last fill:#bfb6fc
+```
+
+## Inputs
+
+- indexed session metadata
+- canonical trace JSONL path
+- project or custom scope identity
+- recent record manifest for duplicate awareness
+
+## Flow
+
+1. `resolve_scope` prepares the context-store target.
+2. `read_window` reads a deterministic trace window.
+3. `scan_window` observes candidate findings and loops until the trace is read.
+4. `filter_signals` keeps only reusable signal.
+5. `synthesize_records` drafts episode and durable records.
+6. `review_records` checks whether records are useful and well-shaped.
+7. `persist_records` writes validated records and provenance.
+
+## Output
+
+The output is written to the context store with evidence back to the source
+session. A clean run can create no durable records when the trace has no
+reusable context.

--- a/docs/cli/project.md
+++ b/docs/cli/project.md
@@ -1,6 +1,6 @@
 # lerim project
 
-Register or remove repositories.
+Register or remove project paths.
 
 ## Summary
 
@@ -12,9 +12,21 @@ They are not storage roots.
 ```bash
 lerim project add .
 lerim project add ~/codes/my-app
+lerim project add ~/lerim-traces/support-clean --type custom
 lerim project list
 lerim project remove my-app
 ```
+
+## Source type
+
+`lerim project add` defaults to `--type supported`.
+
+Use `--type supported` for normal projects whose sessions come from connected
+Claude Code, Codex CLI, Cursor, or OpenCode adapters.
+
+Use `--type custom` for folders of already-clean Lerim canonical JSONL traces.
+Custom projects are read directly. Lerim does not compact, rewrite, normalize,
+or clean files in custom folders.
 
 ## How it works
 

--- a/docs/cli/trace.md
+++ b/docs/cli/trace.md
@@ -1,16 +1,23 @@
 # lerim trace
 
-Import explicit generic agent traces.
+Import one explicit generic trace file.
 
 ## Overview
 
-`lerim trace import` is the current bridge for custom agents and business
-workflows that are not one of the built-in connected sources.
+`lerim trace import` is a host-only one-file import utility.
 
 Built-in `connect` adapters discover sessions from supported local tools such as
-Claude Code, Codex CLI, Cursor, and OpenCode. Custom agents work differently
-today: the agent or surrounding system should write a trace file, then call
-`lerim trace import` for that run.
+Claude Code, Codex CLI, Cursor, and OpenCode.
+
+Custom agents should normally use custom trace folders:
+
+```bash
+lerim project add ~/lerim-traces/support-clean --type custom
+lerim ingest --agent custom
+```
+
+Use `trace import` only when you intentionally want to import one standalone
+file into a non-project scope.
 
 ## Syntax
 
@@ -81,5 +88,5 @@ Scope decides where imported context belongs.
 | `user` | Personal assistant context |
 | `custom` | Customer-defined boundary |
 
-For customer deployments, the import call is the integration point: an adapter
-can export each run's trace and call `lerim trace import` automatically.
+For ongoing custom-agent workflows, prefer
+[Custom Trace Folders](../guides/custom-trace-folders.md).

--- a/docs/concepts/business-workflows.md
+++ b/docs/concepts/business-workflows.md
@@ -81,17 +81,19 @@ lerim answer "What release constraints did previous agents discover?"
 
 ## Current source boundary
 
-The open-source package includes the trace-to-context foundation and supported
-source adapters. Customer deployments can adapt the input layer around the
-business traces that matter for a pilot workflow.
+The open-source package includes the trace-to-context foundation, supported
+source adapters, and custom clean-trace folders. Customer pilots can start by
+choosing one workflow, cleaning its traces into Lerim canonical JSONL, and
+registering that folder as a custom project.
 
-For custom agents today, the practical path is `lerim trace import`: export a
-JSON, JSONL, or text trace from the agent run, choose a scope such as `domain`,
-`workspace`, `project`, or `custom`, and let Lerim normalize and ingest it.
-Customer adapters can automate that import step once the pilot workflow is
-clear.
+For custom agents today, the practical path is:
+
+```bash
+lerim project add ~/lerim-traces/support-clean --type custom
+lerim ingest --agent custom
+```
 
 If the source trace contains customer-specific noise or sensitive fields, run a
-customer-owned cleaner before import. Lerim filters for durable business signal,
-but pre-import cleaning is still the right boundary for secrets, regulated data,
-large raw tool outputs, and retention policy.
+customer-owned cleaner before the files enter that folder. Lerim filters for
+durable business signal, but pre-ingest cleaning is still the right boundary for
+secrets, regulated data, large raw tool outputs, and retention policy.

--- a/docs/concepts/how-it-works.md
+++ b/docs/concepts/how-it-works.md
@@ -6,17 +6,17 @@ Lerim is trace-to-context infrastructure for repeated agent work.
 
 The flow is:
 
-1. adapters read raw agent traces from supported sources
-2. traces are normalized
+1. supported adapters read raw agent traces, or custom projects provide clean canonical traces
+2. supported traces are normalized; custom traces are already clean
 3. the trace ingestor extracts durable context records and drops low-value candidates
 4. the context curator cleans, merges, archives, and supersedes records
 5. the context-brief compiler generates fast startup context from records
 6. the context answerer retrieves records and answers questions
 
-The current package includes supported source adapters. Customer deployments can
-adapt the input layer around business traces such as research briefs, support
-handoffs, incident investigations, revenue workflows, and custom internal agent
-logs.
+The current package includes supported source adapters and custom clean-trace
+folders. Customer deployments can adapt the input layer around business traces
+such as research briefs, support handoffs, incident investigations, revenue
+workflows, and custom internal agent logs.
 
 For operational targets and scale boundaries, see
 [Capacity and SLOs](capacity-and-slos.md).
@@ -25,7 +25,7 @@ For operational targets and scale boundaries, see
 
 ```mermaid
 flowchart TD
-    A["Agent activity sources"] --> B["Source adapters and generic import"]
+    A["Agent activity sources"] --> B["Supported adapters or custom clean folders"]
     B --> C["Session catalog and work queue"]
     C --> D["Ingest"]
     D --> E["Durable-signal filter"]

--- a/docs/concepts/ingest-curate.md
+++ b/docs/concepts/ingest-curate.md
@@ -3,7 +3,7 @@
 Lerim has two runtime paths that keep the shared context store accurate and
 clean:
 
-- **Trace ingestion** (hot path) -- processes supported agent traces and extracts context records
+- **Trace ingestion** (hot path) -- processes supported traces or custom clean traces and extracts context records
 - **Context curation** (cold path) -- refines existing records offline
 
 Both run automatically in the daemon loop and can also be triggered manually.
@@ -16,10 +16,10 @@ structured review and synthesis.
 
 The ingestion path turns raw agent traces into structured context records:
 
-1. **Discover** -- adapters scan session directories for new sessions within the time window
+1. **Discover** -- adapters scan supported session directories; custom projects scan clean `.jsonl` folders directly
 2. **Index** -- new sessions are cataloged in `sessions.sqlite3`
 3. **Match to project** -- sessions matching a registered project are enqueued; unmatched sessions are indexed but not extracted
-4. **Compact** -- traces are compacted and cached
+4. **Prepare trace** -- supported traces are compacted and cached; custom traces are read directly because they are already canonical
 5. **Trace-to-context flow** -- the ingest flow reads deterministic trace windows, observes typed findings, filters for durable signal, writes the final context payload, and stores one episode record plus zero or more durable records
 
 ### Record quality contract

--- a/docs/concepts/supported-agents.md
+++ b/docs/concepts/supported-agents.md
@@ -4,7 +4,7 @@ Lerim turns agent traces into reusable context across business workflows.
 
 The context model is meant to sit above support, research, operations, revenue,
 custom business agents, and engineering automation. Current adapters cover
-supported sources available today while the broader trace-import layer expands.
+supported sources available today. Custom agents use clean trace folders.
 
 ## Current adapters
 
@@ -22,32 +22,26 @@ It only feeds the extraction flow.
 
 ## Custom and business-agent traces
 
-For a custom agent, the current bridge is explicit import:
+For a custom agent, create a folder of already-clean Lerim canonical JSONL files
+and register it as a custom project:
 
 ```bash
-lerim trace import ./agent-run.jsonl \
-  --source-name support-bot \
-  --source-profile support \
-  --scope-type domain \
-  --scope support
+lerim project add ~/lerim-traces/support-clean --type custom
+lerim ingest --agent custom
 ```
 
-The custom agent or surrounding system produces a JSON, JSONL, or text trace.
-Lerim normalizes that file, writes a canonical compact copy under the Lerim
-workspace, registers the selected scope, and runs ingestion into the shared
-context store.
-
-Built-in adapters monitor known tools automatically. Custom agents currently use
-explicit import unless a customer deployment adds a workflow-specific adapter.
+Each `.jsonl` file is one completed agent or workflow session. Custom mode does
+not run a Lerim adapter and does not compact or normalize files. It reads the
+clean files directly and indexes them as `agent_type=custom`.
 
 For sensitive or very noisy traces, run a customer-owned cleaner before import.
 Lerim can filter reusable signal during ingestion, but it should not be treated
 as the only redaction, privacy, or retention-control layer for arbitrary custom
 source data.
 
-## Custom business trace import
+## Custom business trace cleaning
 
-A customer-specific trace import should preserve enough structure for Lerim to
+A customer-specific cleaner should preserve enough structure for Lerim to
 separate routine activity from reusable context.
 
 Useful fields include:

--- a/docs/configuration/config-toml.md
+++ b/docs/configuration/config-toml.md
@@ -68,6 +68,10 @@ endpoint = "https://api.lerim.dev"
 
 [projects]
 # my-project = "~/codes/my-project"
+
+[project_types]
+# Optional. Omitted projects default to "supported".
+# my-custom-traces = "custom"
 ```
 
 ## Notes
@@ -79,3 +83,4 @@ endpoint = "https://api.lerim.dev"
 - there is one active model role today: `[roles.agent]`
 - API keys come from environment variables, not TOML
 - `curate_max_llm_calls` caps context-curator BAML calls; `answer_max_retrieval_actions` caps context-answerer retrieval actions
+- `[project_types]` marks custom clean-trace folders; accepted values are `supported` and `custom`

--- a/docs/configuration/overview.md
+++ b/docs/configuration/overview.md
@@ -20,6 +20,7 @@ Priority order:
 - `[cloud]`
 - `[agents]`
 - `[projects]`
+- `[project_types]`
 
 ## Important paths
 

--- a/docs/guides/connecting-agents.md
+++ b/docs/guides/connecting-agents.md
@@ -2,9 +2,8 @@
 
 Lerim reads trace data from supported sources and turns it into reusable context.
 
-The commands below connect the sources available today. Generic trace import
-and broader source support are the direction for support, research, operations,
-revenue, compliance, and custom business-agent workflows.
+The commands below connect the supported sources available today. For custom
+agents and business workflows, use a custom trace folder instead of `connect`.
 
 ## Auto-detect
 
@@ -32,3 +31,15 @@ lerim connect claude --path /custom/path
 ```bash
 lerim connect list
 ```
+
+## Custom agents
+
+Custom agents do not use `lerim connect`. Export and clean their traces into
+Lerim canonical JSONL, then register the clean folder as a custom project:
+
+```bash
+lerim project add ~/lerim-traces/support-clean --type custom
+lerim ingest --agent custom
+```
+
+See [Custom Trace Folders](custom-trace-folders.md).

--- a/docs/guides/custom-trace-folders.md
+++ b/docs/guides/custom-trace-folders.md
@@ -1,0 +1,161 @@
+# Custom Trace Folders
+
+Custom trace folders are for agents or business workflows that Lerim does not
+support with a built-in adapter yet.
+
+The boundary is intentionally simple:
+
+- Supported agents use Lerim adapters and compaction.
+- Custom agents provide already-clean Lerim canonical JSONL traces.
+- Lerim scans the folder as one project with type `custom`.
+- Lerim does not compact, rewrite, normalize, or clean custom traces.
+
+## User Journey
+
+1. Export raw traces from your agent, ticket workflow, research workflow, or
+   internal automation.
+2. Write your own cleaner that converts those raw traces into Lerim canonical
+   JSONL.
+3. Put the cleaned `.jsonl` files in one folder.
+4. Register that folder as a custom project.
+5. Run Lerim ingest. Lerim indexes the clean files and extracts reusable
+   context.
+
+```bash
+mkdir -p ~/lerim-traces/support-clean
+
+lerim project add ~/lerim-traces/support-clean --type custom
+lerim ingest --agent custom
+```
+
+Each `.jsonl` file is treated as one source session. Nested folders are fine:
+
+```text
+support-clean/
+  renewals/
+    run-2026-05-16-001.jsonl
+  incidents/
+    run-2026-05-16-002.jsonl
+```
+
+## Canonical JSONL Schema
+
+Each non-empty line must be one JSON object with exactly these keys:
+
+```json
+{"type":"user","message":{"role":"user","content":"Customer asked for renewal approval."},"timestamp":"2026-05-16T09:00:00Z"}
+{"type":"assistant","message":{"role":"assistant","content":"Agent found approval is required above EUR 500."},"timestamp":"2026-05-16T09:02:00Z"}
+```
+
+Rules:
+
+- `type` is `user` or `assistant`
+- `message.role` is `user` or `assistant`
+- `message.content` is a string or a list of structured content blocks
+- `timestamp` is an ISO timestamp string or `null`
+- one file equals one agent/workflow session
+
+Invalid files are skipped and logged. Lerim does not try to repair custom
+traces because cleaning belongs to the source owner.
+
+## Paste This Prompt Into Your Coding Agent
+
+Use this prompt with Codex, Claude Code, or another coding agent in the folder
+that contains your raw trace samples.
+
+```text
+You are helping me create a trace cleaner for Lerim.
+
+Goal:
+Convert raw agent or workflow traces into Lerim canonical JSONL files.
+
+Important boundary:
+Lerim custom mode expects already-clean traces. Lerim will not compact, rewrite,
+normalize, redact, or repair these files. The cleaning script we write here is
+the source-specific adapter and privacy boundary.
+
+Input:
+- Inspect the raw trace files in this folder.
+- Identify what represents one completed agent/workflow run.
+- Write one output .jsonl file per run.
+
+Output schema:
+Each non-empty JSONL line must be exactly:
+
+{
+  "type": "user" | "assistant",
+  "message": {
+    "role": "user" | "assistant",
+    "content": string | list
+  },
+  "timestamp": string | null
+}
+
+Mapping guidance:
+- Use "user" for the human, customer, requester, system trigger, ticket text,
+  workflow request, or external input.
+- Use "assistant" for the agent, automation, analyst, support bot, tool-using
+  workflow, or generated response/action.
+- Preserve useful chronology.
+- Preserve decisions, constraints, evidence, assumptions, approvals, open
+  questions, handoffs, tool results, source links, ticket ids, account ids,
+  incident ids, and workflow ids when they are useful for future context.
+- Drop binary blobs, screenshots, huge raw payloads, duplicate logs, progress
+  noise, stack traces that add no future context, and vendor metadata that does
+  not help future agents.
+- Redact secrets, access tokens, private keys, passwords, session cookies,
+  regulated personal data, and any fields our retention policy forbids.
+- Do not invent missing facts.
+- Do not use keyword matching as the main cleaning strategy. Parse the source
+  structure and map its fields deliberately.
+
+Script requirements:
+- Create a Python script named clean_to_lerim_jsonl.py.
+- The script should accept:
+  --input <raw-trace-folder-or-file>
+  --output <clean-output-folder>
+- It should create the output folder if needed.
+- It should validate every output line against the schema above.
+- It should fail loudly on unknown source shapes instead of silently producing
+  bad traces.
+- It should print a summary with files read, sessions written, rows written,
+  skipped items, and redaction count if redaction is implemented.
+
+After writing the script:
+1. Run it on the sample traces.
+2. Show me the generated output tree.
+3. Show me two short sample output lines.
+4. Explain any source fields you dropped and why.
+```
+
+After the cleaner runs, register the clean output folder:
+
+```bash
+python clean_to_lerim_jsonl.py \
+  --input ./raw-traces \
+  --output ~/lerim-traces/support-clean
+
+lerim project add ~/lerim-traces/support-clean --type custom
+lerim ingest --agent custom
+```
+
+## How This Differs From Supported Agents
+
+Supported sources such as Claude Code, Codex CLI, Cursor, and OpenCode use
+Lerim adapters. Those adapters know where the source stores sessions, compact
+source-specific events, and place canonical files under Lerim's cache.
+
+Custom mode skips that adapter path. It reads your cleaned `.jsonl` files
+directly from the registered folder and indexes them as `agent_type=custom`.
+
+## Operational Checks
+
+```bash
+lerim project list
+lerim ingest --agent custom --no-extract
+lerim queue --status pending
+lerim status --live
+```
+
+Use `--no-extract` when you want to verify that the folder is discovered before
+running model-backed extraction.

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,8 @@ Lerim sits above agent workflows, extracts durable signal from their traces, and
 
 The product direction is a context compiler for support, research, operations,
 revenue, custom business agents, and engineering automation. Current adapters
-are one compatibility path while the broader trace-import layer expands.
+are one compatibility path; custom clean-trace folders are the path for other
+agents and business workflows.
 
 If you are evaluating Lerim, start with the workflow: traces in, durable context
 out, cited answers and startup context for future agents.
@@ -40,6 +41,7 @@ The operating model is simple:
 - [Installation](installation.md)
 - [Quickstart](quickstart.md)
 - [Business Workflows](concepts/business-workflows.md)
+- [Custom Trace Folders](guides/custom-trace-folders.md)
 - [How It Works](concepts/how-it-works.md)
 - [Context Brief](concepts/context-brief.md)
 - [CLI Overview](cli/overview.md)

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -3,9 +3,9 @@
 This is the shortest real path.
 
 The open-source quickstart uses the sources available in the current package.
-Customer deployments can adapt trace imports around a specific business workflow
-such as support escalations, research briefs, incidents, reviews, or revenue
-handoffs.
+Customer deployments can register custom clean-trace folders around a specific
+business workflow such as support escalations, research briefs, incidents,
+reviews, or revenue handoffs.
 
 ## 1. Prepare
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -121,6 +121,11 @@ nav:
     - lerim serve: cli/serve.md
     - Background loop: cli/daemon.md
     - lerim dashboard: cli/dashboard.md
+  - Agent Architecture:
+    - Trace Ingestion: agents/trace-ingestion.md
+    - Context Curator: agents/context-curator.md
+    - Context Answerer: agents/context-answerer.md
+    - Context Brief: agents/context-brief.md
   - Configuration:
     - Overview: configuration/overview.md
     - config.toml Reference: configuration/config-toml.md
@@ -128,6 +133,7 @@ nav:
     - Tracing: configuration/tracing.md
   - Guides:
     - Connecting Agents: guides/connecting-agents.md
+    - Custom Trace Folders: guides/custom-trace-folders.md
     - Dashboard: guides/dashboard.md
     - Querying Context: guides/querying-context.md
   - Contributing: contributing/getting-started.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "lerim"
-version = "0.2.0"
+version = "0.2.1"
 description = "Trace-to-context layer for AI agent workflows."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/lerim/config/default.toml
+++ b/src/lerim/config/default.toml
@@ -61,3 +61,8 @@ endpoint = "https://api.lerim.dev"
 [projects]
 # Map project short names to absolute host paths.
 # my-project = "~/codes/my-project"
+
+[project_types]
+# Optional project source type. Omitted projects default to "supported".
+# Use "custom" only for folders of already-clean Lerim canonical JSONL traces.
+# my-custom-traces = "custom"

--- a/src/lerim/config/settings.py
+++ b/src/lerim/config/settings.py
@@ -296,6 +296,7 @@ class Config:
 
     agents: dict[str, str]
     projects: dict[str, str]
+    project_types: dict[str, str]
 
     def public_dict(self) -> dict[str, Any]:
         """Return safe serialized config for CLI/dashboard visibility."""
@@ -318,6 +319,7 @@ class Config:
             "cloud_authenticated": self.cloud_token is not None,
             "connected_agents": sorted(self.agents),
             "project_names": sorted(self.projects),
+            "project_types": dict(sorted(self.project_types.items())),
         }
 
 
@@ -365,6 +367,28 @@ def _parse_string_table(raw: dict[str, Any], *, section: str = "config") -> dict
     return result
 
 
+PROJECT_TYPE_SUPPORTED = "supported"
+PROJECT_TYPE_CUSTOM = "custom"
+PROJECT_TYPE_CHOICES = frozenset({PROJECT_TYPE_SUPPORTED, PROJECT_TYPE_CUSTOM})
+
+
+def normalize_project_type(value: str | None) -> str:
+    """Normalize a configured project source type."""
+    text = (value or PROJECT_TYPE_SUPPORTED).strip().lower()
+    if not text:
+        return PROJECT_TYPE_SUPPORTED
+    if text not in PROJECT_TYPE_CHOICES:
+        allowed = ", ".join(sorted(PROJECT_TYPE_CHOICES))
+        raise ValueError(f"project type must be one of: {allowed}")
+    return text
+
+
+def _parse_project_types_table(raw: dict[str, Any]) -> dict[str, str]:
+    """Parse project-name to source-type mappings."""
+    parsed = _parse_string_table(raw, section="project_types")
+    return {name: normalize_project_type(value) for name, value in parsed.items()}
+
+
 def _default_context_db_path(global_data_dir: Path) -> Path:
     """Return the canonical global context DB path for the current data root."""
     return global_data_dir / "context.sqlite3"
@@ -380,6 +404,7 @@ _TOP_LEVEL_CONFIG_KEYS = {
     "cloud",
     "agents",
     "projects",
+    "project_types",
 }
 _DATA_KEYS = {"dir", "context_db_path"}
 _SEMANTIC_SEARCH_KEYS = {
@@ -515,6 +540,7 @@ def load_config() -> Config:
 
     agents = _parse_string_table(_ensure_dict(toml_data, "agents"), section="agents")
     projects = _parse_string_table(_ensure_dict(toml_data, "projects"), section="projects")
+    project_types = _parse_project_types_table(_ensure_dict(toml_data, "project_types"))
 
     cloud_endpoint = _to_non_empty_string(os.environ.get("LERIM_CLOUD_ENDPOINT"))
     if not cloud_endpoint:
@@ -579,6 +605,7 @@ def load_config() -> Config:
         cloud_token=cloud_token or None,
         agents=agents,
         projects=projects,
+        project_types=project_types,
     )
 
 

--- a/src/lerim/server/api.py
+++ b/src/lerim/server/api.py
@@ -43,9 +43,11 @@ from lerim.server.docker_runtime import (
 )
 from lerim.config.settings import (
     Config,
+    PROJECT_TYPE_SUPPORTED,
     get_config,
     get_user_config_path,
     load_toml_file,
+    normalize_project_type,
     remove_legacy_memory_dir,
     save_config_patch,
     _write_config_full,
@@ -1308,6 +1310,7 @@ def api_project_list(*, include_paths: bool = True) -> list[dict[str, Any]]:
         item: dict[str, Any] = {
             "name": name,
             "project_id": resolve_project_identity(resolved).project_id,
+            "type": config.project_types.get(name, PROJECT_TYPE_SUPPORTED),
             "exists": resolved.exists(),
         }
         if include_paths:
@@ -1326,17 +1329,31 @@ def _project_config_name(resolved: Path, existing_projects: dict[str, str]) -> s
     return f"{base_name}-{suffix}"
 
 
-def api_project_add(path_str: str, *, include_paths: bool = True) -> dict[str, Any]:
+def api_project_add(
+    path_str: str,
+    *,
+    project_type: str = PROJECT_TYPE_SUPPORTED,
+    include_paths: bool = True,
+) -> dict[str, Any]:
     """Register a project directory and return status."""
     resolved = Path(path_str).expanduser().resolve()
     if not resolved.is_dir():
         message = f"Not a directory: {resolved}" if include_paths else "Not a directory"
         return {"error": message, "name": None}
+    try:
+        resolved_project_type = normalize_project_type(project_type)
+    except ValueError as exc:
+        return {"error": str(exc), "name": None}
 
     config = get_config()
     name = _project_config_name(resolved, config.projects or {})
     # Update config
-    save_config_patch({"projects": {name: str(resolved)}})
+    save_config_patch(
+        {
+            "projects": {name: str(resolved)},
+            "project_types": {name: resolved_project_type},
+        }
+    )
     config = get_config()
     store = _context_store(config)
     identity = resolve_project_identity(resolved)
@@ -1345,6 +1362,7 @@ def api_project_add(path_str: str, *, include_paths: bool = True) -> dict[str, A
     payload: dict[str, Any] = {
         "name": name,
         "project_id": identity.project_id,
+        "type": resolved_project_type,
     }
     if include_paths:
         payload["path"] = str(resolved)
@@ -1367,6 +1385,10 @@ def api_project_remove(name: str) -> dict[str, Any]:
     if isinstance(projects, dict) and name in projects:
         del projects[name]
         existing["projects"] = projects
+    project_types = existing.get("project_types", {})
+    if isinstance(project_types, dict) and name in project_types:
+        del project_types[name]
+        existing["project_types"] = project_types
 
     # Write directly — save_config_patch would re-merge the deleted key
     _write_config_full(existing)

--- a/src/lerim/server/cli.py
+++ b/src/lerim/server/cli.py
@@ -1099,7 +1099,8 @@ def _cmd_project(args: argparse.Namespace) -> int:
         _emit(f"Registered projects: {len(projects)}")
         for p in projects:
             status = "ok" if p["exists"] else "missing"
-            _emit(f"  {p['name']}: {p['path']} ({status})")
+            project_type = str(p.get("type") or "supported")
+            _emit(f"  {p['name']}: {p['path']} ({project_type}, {status})")
         return 0
 
     if action == "add":
@@ -1107,11 +1108,16 @@ def _cmd_project(args: argparse.Namespace) -> int:
         if not path_str:
             _emit("Usage: lerim project add <path>", file=sys.stderr)
             return 2
-        result = api_project_add(path_str)
+        result = api_project_add(
+            path_str,
+            project_type=str(getattr(args, "project_type", "supported") or "supported"),
+        )
         if result.get("error"):
             _emit(result["error"], file=sys.stderr)
             return 1
-        _emit(f'Added project "{result["name"]}" ({result["path"]})')
+        _emit(
+            f'Added project "{result["name"]}" ({result["path"]}, type={result["type"]})'
+        )
         return _restart_docker_for_project_change(
             "Restarting Lerim to mount new project..."
         )
@@ -2137,6 +2143,17 @@ def build_parser() -> argparse.ArgumentParser:
         help="Register a project directory",
     )
     proj_add.add_argument("path", help="Path to the project directory.")
+    proj_add.add_argument(
+        "--type",
+        dest="project_type",
+        choices=["supported", "custom"],
+        default="supported",
+        help=(
+            "Project source type. Use 'supported' for normal projects connected to "
+            "Claude/Codex/Cursor/OpenCode adapters; use 'custom' for folders of "
+            "already-clean Lerim canonical JSONL traces."
+        ),
+    )
 
     project_sub.add_parser(
         "list",

--- a/src/lerim/server/httpd.py
+++ b/src/lerim/server/httpd.py
@@ -940,7 +940,12 @@ SELECT COUNT(1) AS total FROM session_docs d WHERE 1=1{where_sql}"""
             if not proj_path:
                 self._error(HTTPStatus.BAD_REQUEST, "Missing 'path'")
                 return
-            result = api_project_add(proj_path, include_paths=False)
+            project_type = str(body.get("type") or "supported").strip() or "supported"
+            result = api_project_add(
+                proj_path,
+                project_type=project_type,
+                include_paths=False,
+            )
             status_code = (
                 HTTPStatus.BAD_REQUEST if result.get("error") else HTTPStatus.OK
             )

--- a/src/lerim/sessions/catalog.py
+++ b/src/lerim/sessions/catalog.py
@@ -15,7 +15,8 @@ from typing import Any, Callable
 from lerim.adapters import registry as adapter_registry
 from lerim.config.project_scope import match_session_project
 from lerim.config.logging import logger
-from lerim.config.settings import get_config, reload_config
+from lerim.config.settings import PROJECT_TYPE_CUSTOM, get_config, reload_config
+from lerim.sessions.custom_traces import iter_custom_trace_sessions
 
 
 JOB_TYPE_EXTRACT = "extract"
@@ -637,7 +638,7 @@ def index_new_sessions(
     skip_unscoped: bool = False,
     stats: dict[str, int] | None = None,
 ) -> int | list[IndexedSession]:
-    """Discover and index new sessions from connected adapters.
+    """Discover and index new sessions from connected adapters and custom folders.
 
     Known sessions with the same content hash are skipped. New sessions are
     returned with ``changed=False``; known sessions with a missing or different
@@ -657,12 +658,15 @@ def index_new_sessions(
     selected_agents = agents or adapter_registry.get_connected_agents(
         config.platforms_path
     )
+    selected_agent_set = set(selected_agents)
     known_ids = get_indexed_run_ids()
     known_hashes = _get_indexed_content_hashes()
 
     new_sessions: list[IndexedSession] = []
 
     for agent_name in selected_agents:
+        if agent_name == PROJECT_TYPE_CUSTOM:
+            continue
         adapter = adapter_registry.get_adapter(agent_name)
         traces_dir = connected_paths.get(agent_name)
         if adapter is None or traces_dir is None:
@@ -693,56 +697,87 @@ def index_new_sessions(
                         )
                     continue
 
-            content_hash = getattr(session, "content_hash", None)
-            previous_hash = known_hashes.get(session.run_id)
-            is_known = session.run_id in known_ids
-            if is_known and content_hash is not None and previous_hash == content_hash:
-                continue
-            is_changed = is_known
-
-            summaries_json = json.dumps(session.summaries, ensure_ascii=True)
-            summary_text = "\n".join(item for item in session.summaries if item)
-            content = summary_text
-            if not content:
-                content = f"run:{session.run_id} agent:{session.agent_type}"
-
-            indexed = index_session_for_fts(
-                run_id=session.run_id,
-                agent_type=session.agent_type,
-                content=content,
-                repo_path=session.repo_path,
-                repo_name=session.repo_name,
-                start_time=session.start_time,
-                status=session.status,
-                duration_ms=session.duration_ms,
-                message_count=session.message_count,
-                tool_call_count=session.tool_call_count,
-                error_count=session.error_count,
-                total_tokens=session.total_tokens,
-                summaries=summaries_json,
-                summary_text=summary_text,
-                session_path=session.session_path,
-                content_hash=content_hash,
+            indexed_session = _index_discovered_session(
+                session=session,
+                known_ids=known_ids,
+                known_hashes=known_hashes,
             )
-            if not indexed:
-                continue
+            if indexed_session is not None:
+                new_sessions.append(indexed_session)
 
-            known_ids.add(session.run_id)
-            known_hashes[session.run_id] = content_hash
-            new_sessions.append(
-                IndexedSession(
-                    run_id=session.run_id,
-                    agent_type=session.agent_type,
-                    session_path=session.session_path,
-                    start_time=session.start_time,
-                    repo_path=session.repo_path,
-                    changed=is_changed,
+    if not agents or PROJECT_TYPE_CUSTOM in selected_agent_set:
+        for project_name, project_path_str in config.projects.items():
+            if config.project_types.get(project_name) != PROJECT_TYPE_CUSTOM:
+                continue
+            sessions = iter_custom_trace_sessions(
+                project_name=project_name,
+                project_path=Path(project_path_str),
+                start=start,
+                end=end,
+            )
+            for session in sessions:
+                indexed_session = _index_discovered_session(
+                    session=session,
+                    known_ids=known_ids,
+                    known_hashes=known_hashes,
                 )
-            )
+                if indexed_session is not None:
+                    new_sessions.append(indexed_session)
 
     # Sort chronologically (oldest first) so later sessions can update earlier ones.
     new_sessions.sort(key=lambda s: s.start_time or "")
     return new_sessions if return_details else len(new_sessions)
+
+
+def _index_discovered_session(
+    *,
+    session: Any,
+    known_ids: set[str],
+    known_hashes: dict[str, str | None],
+) -> IndexedSession | None:
+    """Persist one discovered session row and return its queue payload."""
+    content_hash = getattr(session, "content_hash", None)
+    previous_hash = known_hashes.get(session.run_id)
+    is_known = session.run_id in known_ids
+    if is_known and content_hash is not None and previous_hash == content_hash:
+        return None
+    is_changed = is_known
+
+    summaries_json = json.dumps(session.summaries, ensure_ascii=True)
+    summary_text = "\n".join(item for item in session.summaries if item)
+    content = summary_text or f"run:{session.run_id} agent:{session.agent_type}"
+
+    indexed = index_session_for_fts(
+        run_id=session.run_id,
+        agent_type=session.agent_type,
+        content=content,
+        repo_path=session.repo_path,
+        repo_name=session.repo_name,
+        start_time=session.start_time,
+        status=session.status,
+        duration_ms=session.duration_ms,
+        message_count=session.message_count,
+        tool_call_count=session.tool_call_count,
+        error_count=session.error_count,
+        total_tokens=session.total_tokens,
+        summaries=summaries_json,
+        summary_text=summary_text,
+        session_path=session.session_path,
+        content_hash=content_hash,
+    )
+    if not indexed:
+        return None
+
+    known_ids.add(session.run_id)
+    known_hashes[session.run_id] = content_hash
+    return IndexedSession(
+        run_id=session.run_id,
+        agent_type=session.agent_type,
+        session_path=session.session_path,
+        start_time=session.start_time,
+        repo_path=session.repo_path,
+        changed=is_changed,
+    )
 
 
 def enqueue_session_job(

--- a/src/lerim/sessions/custom_traces.py
+++ b/src/lerim/sessions/custom_traces.py
@@ -1,0 +1,177 @@
+"""Custom trace-folder scanner.
+
+Custom projects are folders of already-clean Lerim canonical JSONL traces. They
+are not platform adapters: Lerim does not compact, rewrite, or normalize these
+files before ingestion.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from loguru import logger
+
+from lerim.adapters.base import SessionRecord
+from lerim.adapters.common import (
+    compute_file_hash,
+    parse_timestamp,
+    validate_canonical_entry,
+)
+
+CUSTOM_AGENT_TYPE = "custom"
+
+
+def iter_custom_trace_sessions(
+    *,
+    project_name: str,
+    project_path: Path,
+    start: datetime | None = None,
+    end: datetime | None = None,
+) -> list[SessionRecord]:
+    """Return custom trace sessions from one registered custom project folder."""
+    root = project_path.expanduser().resolve()
+    if not root.is_dir():
+        return []
+
+    sessions: list[SessionRecord] = []
+    for trace_path in sorted(root.rglob("*.jsonl")):
+        if not trace_path.is_file():
+            continue
+        try:
+            rows = _load_clean_trace(trace_path)
+        except ValueError as exc:
+            logger.warning(
+                "custom trace skipped | project={} path={} error={}",
+                project_name,
+                trace_path,
+                str(exc),
+            )
+            continue
+        if not rows:
+            continue
+
+        started_at = _first_timestamp(rows)
+        parsed_started_at = parse_timestamp(started_at)
+        if not _in_window(parsed_started_at, start=start, end=end):
+            continue
+
+        rel_path = trace_path.relative_to(root)
+        run_id = _custom_run_id(root=root, relative_path=rel_path)
+        sessions.append(
+            SessionRecord(
+                run_id=run_id,
+                agent_type=CUSTOM_AGENT_TYPE,
+                session_path=str(trace_path),
+                start_time=started_at,
+                repo_path=str(root),
+                repo_name=project_name,
+                status="completed",
+                message_count=len(rows),
+                tool_call_count=sum(_tool_block_count(row) for row in rows),
+                summaries=_summaries(rows),
+                content_hash=compute_file_hash(trace_path),
+            )
+        )
+    return sessions
+
+
+def _load_clean_trace(path: Path) -> list[dict[str, Any]]:
+    """Load a strict canonical JSONL trace file."""
+    rows: list[dict[str, Any]] = []
+    for line_number, raw_line in enumerate(
+        path.read_text(encoding="utf-8").splitlines(), start=1
+    ):
+        line = raw_line.strip()
+        if not line:
+            continue
+        try:
+            item = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"line {line_number} is not JSON") from exc
+        if not isinstance(item, dict) or not validate_canonical_entry(item):
+            raise ValueError(f"line {line_number} is not Lerim canonical trace schema")
+        rows.append(item)
+    if not rows:
+        raise ValueError("trace file is empty")
+    return rows
+
+
+def _first_timestamp(rows: list[dict[str, Any]]) -> str | None:
+    """Return the first parseable timestamp in the trace."""
+    for row in rows:
+        timestamp = row.get("timestamp")
+        if parse_timestamp(timestamp) is not None:
+            return str(timestamp)
+    return None
+
+
+def _in_window(
+    started_at: datetime | None,
+    *,
+    start: datetime | None,
+    end: datetime | None,
+) -> bool:
+    """Return whether a session timestamp overlaps the ingest window."""
+    if started_at is None:
+        return True
+    if started_at.tzinfo is None:
+        started_at = started_at.replace(tzinfo=UTC)
+    if start is not None and started_at < start:
+        return False
+    if end is not None and started_at > end:
+        return False
+    return True
+
+
+def _custom_run_id(*, root: Path, relative_path: Path) -> str:
+    """Return a stable custom-session id from project root and relative file path."""
+    digest = hashlib.sha1(
+        f"{root}\0{relative_path.as_posix()}".encode("utf-8")
+    ).hexdigest()[:20]
+    return f"custom_{digest}"
+
+
+def _tool_block_count(row: dict[str, Any]) -> int:
+    """Count explicit tool-like blocks in one canonical trace row."""
+    content = row.get("message", {}).get("content")
+    if not isinstance(content, list):
+        return 0
+    total = 0
+    for block in content:
+        if isinstance(block, dict) and str(block.get("type") or "").strip() in {
+            "tool_use",
+            "tool_result",
+            "function_call",
+            "function_result",
+        }:
+            total += 1
+    return total
+
+
+def _summaries(rows: list[dict[str, Any]]) -> list[str]:
+    """Build lightweight catalog summaries without rewriting trace content."""
+    summaries: list[str] = []
+    for row in rows[:8]:
+        role = str(row.get("message", {}).get("role") or row.get("type") or "unknown")
+        content = row.get("message", {}).get("content")
+        if isinstance(content, str):
+            text = content.strip().replace("\n", " ")
+        else:
+            text = json.dumps(content, ensure_ascii=True, default=str)
+        if text:
+            summaries.append(f"{role}: {text[:300]}")
+    return summaries
+
+
+if __name__ == "__main__":
+    """Run a tiny canonical-schema smoke check."""
+    sample = {
+        "type": "user",
+        "message": {"role": "user", "content": "hello"},
+        "timestamp": None,
+    }
+    assert validate_canonical_entry(sample)

--- a/src/lerim/skills/cli-reference.md
+++ b/src/lerim/skills/cli-reference.md
@@ -76,16 +76,21 @@ lerim init
 
 ### `lerim project` (host-only)
 
-Manage tracked repositories. Project registration only records the repository path.
-There is no project-local Lerim state directory. Durable Lerim context stays in
-`~/.lerim/context.sqlite3`.
+Manage tracked project paths. Project registration only records the path and
+source type. There is no project-local Lerim state directory. Durable Lerim
+context stays in `~/.lerim/context.sqlite3`.
 
 ```bash
 lerim project add ~/codes/my-app       # register a project
 lerim project add .                     # register current directory
+lerim project add ~/traces --type custom # register clean custom traces
 lerim project list                      # show all registered projects
 lerim project remove my-app             # unregister a project
 ```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--type` | `supported` | `supported` for projects whose sessions come from connected adapters; `custom` for folders of already-clean Lerim canonical JSONL traces |
 
 Adding/removing a project restarts the Docker container if running.
 
@@ -172,8 +177,8 @@ lerim connect remove claude               # disconnect Claude
 
 ### `lerim ingest`
 
-Hot-path: discover new agent sessions from connected platforms, enqueue them,
-and run BAML plus LangGraph extraction to create context records.
+Hot-path: discover new sessions from connected platforms and custom clean-trace
+folders, enqueue them, and run extraction to create context records.
 Requires a running server (`lerim up` or `lerim serve`).
 
 **Time window** controls which sessions to scan:
@@ -188,6 +193,7 @@ lerim ingest                          # ingest using configured window (default:
 lerim ingest --window 30d             # ingest last 30 days
 lerim ingest --window all             # ingest everything
 lerim ingest --agent claude,codex     # only ingest these platforms
+lerim ingest --agent custom           # only ingest custom trace folders
 lerim ingest --run-id abc123 --force  # re-extract a specific session
 lerim ingest --since 2026-02-01T00:00:00Z --until 2026-02-08T00:00:00Z
 lerim ingest --no-extract             # index and enqueue only, skip extraction
@@ -215,8 +221,17 @@ Notes:
 
 ### `lerim trace import` (host-only)
 
-Import a JSON, JSONL, or text trace from a custom agent or business workflow,
-normalize it, register the selected scope, and run ingestion.
+Import one JSON, JSONL, or text trace file into an explicit scope.
+
+For ongoing custom-agent workflows, prefer custom project folders:
+
+```bash
+lerim project add ~/lerim-traces/support-clean --type custom
+lerim ingest --agent custom
+```
+
+Use `trace import` only when you intentionally want a one-file import into a
+non-project scope.
 
 ```bash
 lerim trace import ./support-agent-run.jsonl \
@@ -237,9 +252,7 @@ lerim trace import ./support-agent-run.jsonl \
 | `--session-id` | Optional stable session id. Defaults to the normalized trace id |
 
 The imported trace is copied to the Lerim workspace imports directory in compact
-canonical form, then ingested into the shared context store. This is the current
-custom-agent integration point; workflow-specific adapters can automate the
-export-and-import step.
+canonical form, then ingested into the shared context store.
 
 For sensitive or very noisy traces, run a customer-owned cleaner before import.
 Lerim filters for durable signal during ingestion, but it is not the only

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -49,6 +49,7 @@ def make_config(base: Path) -> Config:
         auto_unload=True,
         agents={},
         projects={},
+        project_types={},
         cloud_endpoint="https://api.lerim.dev",
         cloud_token=None,
     )

--- a/tests/integration/custom_traces/__init__.py
+++ b/tests/integration/custom_traces/__init__.py
@@ -1,0 +1,1 @@
+"""Integration tests for custom trace-folder projects."""

--- a/tests/integration/custom_traces/test_cases.py
+++ b/tests/integration/custom_traces/test_cases.py
@@ -1,0 +1,174 @@
+"""Integration tests for custom trace-folder ingestion."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from lerim.config.settings import reload_config
+from lerim.server import daemon
+from lerim.server.api import api_project_add, api_project_list
+from lerim.sessions import catalog
+from tests.helpers import write_test_config
+
+
+def _canonical(role: str, content: str, timestamp: str) -> str:
+    """Return one Lerim canonical JSONL row."""
+    return json.dumps(
+        {
+            "type": role,
+            "message": {"role": role, "content": content},
+            "timestamp": timestamp,
+        }
+    )
+
+
+def _write_trace(path: Path, rows: list[str]) -> None:
+    """Write one synthetic cleaned trace."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(rows) + "\n", encoding="utf-8")
+
+
+@pytest.mark.integration
+def test_custom_project_folder_indexes_and_queues_clean_traces(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Register a custom trace folder and verify Lerim uses its clean traces."""
+    config_path = write_test_config(
+        tmp_path,
+        server={"ingest_window_days": 30, "ingest_max_sessions": 10},
+    )
+    monkeypatch.setenv("LERIM_CONFIG", str(config_path))
+    reload_config()
+
+    trace_root = tmp_path / "support-traces"
+    trace_root.mkdir()
+    first_trace = trace_root / "renewals" / "run-001.jsonl"
+    second_trace = trace_root / "incidents" / "run-002.jsonl"
+    invalid_trace = trace_root / "raw-agent-export.jsonl"
+    _write_trace(
+        first_trace,
+        [
+            _canonical(
+                "user",
+                "Customer asks whether renewal needs legal approval.",
+                "2026-05-16T08:00:00Z",
+            ),
+            _canonical(
+                "assistant",
+                "Agent records that legal approval is required above EUR 500.",
+                "2026-05-16T08:02:00Z",
+            ),
+        ],
+    )
+    _write_trace(
+        second_trace,
+        [
+            _canonical(
+                "user",
+                "Operations agent investigates delayed export paperwork.",
+                "2026-05-16T09:00:00Z",
+            ),
+            _canonical(
+                "assistant",
+                "Agent keeps the customs ticket open until carrier confirmation.",
+                "2026-05-16T09:04:00Z",
+            ),
+        ],
+    )
+    invalid_trace.write_text(
+        '{"role":"assistant","content":"raw vendor shape"}\n',
+        encoding="utf-8",
+    )
+    runtime_calls: list[dict[str, Any]] = []
+
+    class FakeRuntime:
+        def __init__(
+            self,
+            default_cwd: str | None = None,
+            config: Any | None = None,
+        ) -> None:
+            self.default_cwd = default_cwd
+            self.config = config
+
+        def ingest(self, session_path: Path, **kwargs: Any) -> dict[str, Any]:
+            runtime_calls.append(
+                {
+                    "default_cwd": self.default_cwd,
+                    "session_path": str(session_path),
+                    **kwargs,
+                }
+            )
+            return {
+                "records_created": 1,
+                "records_updated": 0,
+                "records_archived": 0,
+                "cost_usd": 0.0,
+            }
+
+    monkeypatch.setattr(daemon, "LerimRuntime", FakeRuntime)
+
+    added = api_project_add(str(trace_root), project_type="custom")
+    assert "error" not in added
+    assert added["type"] == "custom"
+
+    projects = api_project_list()
+    assert projects == [
+        {
+            "name": "support-traces",
+            "project_id": added["project_id"],
+            "type": "custom",
+            "exists": True,
+            "path": str(trace_root.resolve()),
+        }
+    ]
+
+    code, summary = daemon.run_ingest_once(
+        run_id=None,
+        agent_filter=["custom"],
+        no_extract=False,
+        force=False,
+        max_sessions=10,
+        dry_run=False,
+        ignore_lock=True,
+        trigger="integration",
+    )
+
+    assert code == daemon.EXIT_OK
+    assert summary.indexed_sessions == 2
+    assert summary.skipped_sessions == 0
+    assert summary.extracted_sessions == 2
+    assert summary.failed_sessions == 0
+    assert len(summary.run_ids) == 2
+    assert all(run_id.startswith("custom_") for run_id in summary.run_ids)
+
+    docs = [catalog.fetch_session_doc(run_id) for run_id in summary.run_ids]
+    assert all(doc is not None for doc in docs)
+    indexed_paths = {str(doc["session_path"]) for doc in docs if doc}
+    assert indexed_paths == {str(first_trace.resolve()), str(second_trace.resolve())}
+    assert str(invalid_trace.resolve()) not in indexed_paths
+
+    for doc in docs:
+        assert doc is not None
+        assert doc["agent_type"] == "custom"
+        assert doc["repo_path"] == str(trace_root.resolve())
+        assert "/cache/traces/" not in str(doc["session_path"])
+        assert "/workspace/imports/" not in str(doc["session_path"])
+
+    jobs = catalog.list_session_jobs(status=catalog.JOB_STATUS_DONE)
+    assert len(jobs) == 2
+    for job in jobs:
+        assert job["agent_type"] == "custom"
+        assert job["repo_path"] == str(trace_root.resolve())
+        assert job["session_path"] in indexed_paths
+
+    assert len(runtime_calls) == 2
+    for call in runtime_calls:
+        assert call["default_cwd"] == str(trace_root.resolve())
+        assert call["agent_type"] == "custom"
+        assert call["session_path"] in indexed_paths
+        assert call["session_meta"]["cwd"] == str(trace_root.resolve())

--- a/tests/unit/config/test_settings.py
+++ b/tests/unit/config/test_settings.py
@@ -13,6 +13,7 @@ import pytest
 
 from lerim.config.settings import (
     _deep_merge,
+    _parse_project_types_table,
     _parse_string_table,
     _toml_value,
     _toml_write_dict,
@@ -25,6 +26,7 @@ from lerim.config.settings import (
     remove_legacy_memory_dir,
     save_config_patch,
     reload_config,
+    normalize_project_type,
 )
 
 
@@ -100,6 +102,25 @@ def test_parse_string_table_skips_empty():
     raw = {"good": "/path", "bad": "", "none": None}
     result = _parse_string_table(raw, section="agents")
     assert result == {"good": "/path"}
+
+
+def test_normalize_project_type_defaults_to_supported():
+    """Blank project source types default to supported adapters."""
+    assert normalize_project_type(None) == "supported"
+    assert normalize_project_type("") == "supported"
+    assert normalize_project_type(" Supported ") == "supported"
+
+
+def test_parse_project_types_table_accepts_custom():
+    """Project type config maps project names to supported source modes."""
+    result = _parse_project_types_table({"support": "custom", "app": "supported"})
+    assert result == {"support": "custom", "app": "supported"}
+
+
+def test_parse_project_types_table_rejects_unknown_type():
+    """Project type config rejects undocumented source modes."""
+    with pytest.raises(ValueError, match="project type must be one of"):
+        _parse_project_types_table({"support": "adapter"})
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/server/test_api.py
+++ b/tests/unit/server/test_api.py
@@ -954,12 +954,17 @@ def test_api_project_list_with_projects(monkeypatch, tmp_path) -> None:
     proj_dir = tmp_path / "myproject"
     proj_dir.mkdir()
 
-    cfg = replace(make_config(tmp_path), projects={"myproject": str(proj_dir)})
+    cfg = replace(
+        make_config(tmp_path),
+        projects={"myproject": str(proj_dir)},
+        project_types={"myproject": "custom"},
+    )
     monkeypatch.setattr(api_mod, "get_config", lambda: cfg)
 
     result = api_project_list()
     assert len(result) == 1
     assert result[0]["name"] == "myproject"
+    assert result[0]["type"] == "custom"
     assert result[0]["exists"] is True
     assert "has_lerim" not in result[0]
 
@@ -982,6 +987,35 @@ def test_api_project_add_registers_project_in_context_db(monkeypatch, tmp_path) 
     assert not (proj_dir / ".lerim").exists()
     assert len(saved) == 1
     assert "newproject" in saved[0]["projects"]
+    assert saved[0]["project_types"]["newproject"] == "supported"
+
+
+def test_api_project_add_registers_custom_project_type(monkeypatch, tmp_path) -> None:
+    """api_project_add persists the custom source type when requested."""
+    traces_dir = tmp_path / "clean-traces"
+    traces_dir.mkdir()
+    cfg = replace(make_config(tmp_path), projects={})
+
+    saved: list[dict] = []
+    monkeypatch.setattr(api_mod, "save_config_patch", lambda patch: saved.append(patch))
+    monkeypatch.setattr(api_mod, "get_config", lambda: cfg)
+
+    result = api_project_add(str(traces_dir), project_type="custom")
+
+    assert result["name"] == "clean-traces"
+    assert result["type"] == "custom"
+    assert saved[0]["project_types"]["clean-traces"] == "custom"
+
+
+def test_api_project_add_rejects_unknown_project_type(tmp_path) -> None:
+    """api_project_add rejects undocumented source types."""
+    traces_dir = tmp_path / "clean-traces"
+    traces_dir.mkdir()
+
+    result = api_project_add(str(traces_dir), project_type="unknown")
+
+    assert result["name"] is None
+    assert "project type must be one of" in result["error"]
 
 
 def test_api_project_add_disambiguates_duplicate_basenames(
@@ -1003,6 +1037,7 @@ def test_api_project_add_disambiguates_duplicate_basenames(
     assert result["name"] != "service"
     assert result["name"].startswith("service-")
     assert saved[0]["projects"][result["name"]] == str(second.resolve())
+    assert saved[0]["project_types"][result["name"]] == "supported"
 
 
 def test_api_status_reports_projects_and_unscoped(
@@ -1090,13 +1125,18 @@ def test_api_project_remove_success(monkeypatch, tmp_path) -> None:
 
     config_file = tmp_path / "user_config.toml"
     config_file.write_text(
-        '[projects]\nmyproject = "/tmp/myproject"\n', encoding="utf-8"
+        '[projects]\nmyproject = "/tmp/myproject"\n\n'
+        '[project_types]\nmyproject = "custom"\n',
+        encoding="utf-8",
     )
     monkeypatch.setattr(api_mod, "get_user_config_path", lambda: config_file)
-    monkeypatch.setattr(api_mod, "_write_config_full", lambda data: None)
+    written: list[dict] = []
+    monkeypatch.setattr(api_mod, "_write_config_full", lambda data: written.append(data))
 
     result = api_project_remove("myproject")
     assert result["removed"] is True
+    assert written[0]["projects"] == {}
+    assert written[0]["project_types"] == {}
 
 
 def test_api_project_remove_not_found(monkeypatch, tmp_path) -> None:

--- a/tests/unit/server/test_cli_commands.py
+++ b/tests/unit/server/test_cli_commands.py
@@ -1343,6 +1343,7 @@ class TestCmdProject:
         assert code == 0
         text = buf.getvalue()
         assert "myapp" in text
+        assert "supported" in text
         assert ".lerim" not in text
 
     def test_project_list_json(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -1370,9 +1371,10 @@ class TestCmdProject:
         monkeypatch.setattr(
             cli,
             "api_project_add",
-            lambda p: {
+            lambda p, **kwargs: {
                 "name": "myapp",
                 "path": p,
+                "type": kwargs.get("project_type", "supported"),
                 "error": None,
             },
         )
@@ -1386,14 +1388,48 @@ class TestCmdProject:
         assert code == 0
         text = buf.getvalue()
         assert "myapp" in text
+        assert "type=supported" in text
         assert ".lerim" not in text
+
+    def test_project_add_custom_type(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Project add forwards the requested custom source type."""
+        captured: dict[str, str] = {}
+
+        def fake_project_add(path: str, **kwargs):
+            captured["path"] = path
+            captured["project_type"] = kwargs["project_type"]
+            return {
+                "name": "support-traces",
+                "path": path,
+                "type": kwargs["project_type"],
+                "error": None,
+            }
+
+        monkeypatch.setattr(cli, "api_project_add", fake_project_add)
+        monkeypatch.setattr(cli, "is_docker_container_running", lambda: False)
+        args = _ns(
+            command="project",
+            json=False,
+            project_action="add",
+            path="/home/user/support-traces",
+            project_type="custom",
+        )
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            code = cli._cmd_project(args)
+        assert code == 0
+        assert captured == {
+            "path": "/home/user/support-traces",
+            "project_type": "custom",
+        }
+        assert "type=custom" in buf.getvalue()
 
     def test_project_add_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Project add with error response returns 1."""
         monkeypatch.setattr(
             cli,
             "api_project_add",
-            lambda p: {
+            lambda p, **_kwargs: {
                 "error": "path does not exist",
             },
         )
@@ -1412,9 +1448,10 @@ class TestCmdProject:
         monkeypatch.setattr(
             cli,
             "api_project_add",
-            lambda p: {
+            lambda p, **kwargs: {
                 "name": "myapp",
                 "path": p,
+                "type": kwargs.get("project_type", "supported"),
                 "error": None,
             },
         )
@@ -1438,9 +1475,10 @@ class TestCmdProject:
         monkeypatch.setattr(
             cli,
             "api_project_add",
-            lambda p: {
+            lambda p, **kwargs: {
                 "name": "myapp",
                 "path": p,
+                "type": kwargs.get("project_type", "supported"),
                 "error": None,
             },
         )

--- a/tests/unit/server/test_ollama.py
+++ b/tests/unit/server/test_ollama.py
@@ -60,6 +60,7 @@ def _make_ollama_config(
         auto_unload=auto_unload,
         agents={},
         projects={},
+        project_types={},
         cloud_endpoint="https://api.lerim.dev",
         cloud_token=None,
     )

--- a/tests/unit/sessions/test_custom_traces.py
+++ b/tests/unit/sessions/test_custom_traces.py
@@ -1,0 +1,84 @@
+"""Unit tests for custom clean-trace folder discovery."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+
+from lerim.sessions.custom_traces import iter_custom_trace_sessions
+
+
+def _canonical(role: str, content: str, timestamp: str | None = None) -> str:
+    return json.dumps(
+        {
+            "type": role,
+            "message": {"role": role, "content": content},
+            "timestamp": timestamp,
+        }
+    )
+
+
+def test_iter_custom_trace_sessions_reads_clean_jsonl_without_copying(tmp_path) -> None:
+    """A valid custom JSONL file is indexed from its original folder."""
+    trace = tmp_path / "run-1.jsonl"
+    trace.write_text(
+        "\n".join(
+            [
+                _canonical(
+                    "user",
+                    "Renewal customer asked for legal approval.",
+                    "2026-05-16T09:00:00Z",
+                ),
+                _canonical(
+                    "assistant",
+                    "Escalated to legal with the contract note.",
+                    "2026-05-16T09:01:00Z",
+                ),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    sessions = iter_custom_trace_sessions(project_name="support", project_path=tmp_path)
+
+    assert len(sessions) == 1
+    session = sessions[0]
+    assert session.agent_type == "custom"
+    assert session.repo_path == str(tmp_path.resolve())
+    assert session.session_path == str(trace.resolve())
+    assert session.run_id.startswith("custom_")
+    assert session.message_count == 2
+    assert session.content_hash
+
+
+def test_iter_custom_trace_sessions_skips_invalid_schema(tmp_path) -> None:
+    """Custom mode accepts only already-clean canonical JSONL."""
+    (tmp_path / "bad.jsonl").write_text(
+        '{"role":"user","content":"raw"}\n', encoding="utf-8"
+    )
+
+    assert iter_custom_trace_sessions(project_name="support", project_path=tmp_path) == []
+
+
+def test_iter_custom_trace_sessions_applies_time_window(tmp_path) -> None:
+    """The custom scanner respects ingest window bounds."""
+    (tmp_path / "old.jsonl").write_text(
+        _canonical("user", "old", "2026-05-01T09:00:00Z") + "\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "new.jsonl").write_text(
+        _canonical("user", "new", "2026-05-16T09:00:00Z") + "\n",
+        encoding="utf-8",
+    )
+
+    sessions = iter_custom_trace_sessions(
+        project_name="support",
+        project_path=tmp_path,
+        start=datetime(2026, 5, 10, tzinfo=timezone.utc),
+        end=datetime(2026, 5, 17, tzinfo=timezone.utc),
+    )
+
+    assert [item.session_path for item in sessions] == [
+        str((tmp_path / "new.jsonl").resolve())
+    ]

--- a/tests/unit/sessions/test_indexer_paths.py
+++ b/tests/unit/sessions/test_indexer_paths.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -38,6 +39,7 @@ class _FakeAdapter:
                 content_hash="hash-new",
             )
         ]
+
 
 class _FakeCursorAdapter(_FakeAdapter):
     @staticmethod
@@ -105,6 +107,48 @@ def test_index_new_sessions_cursor_path_ingestion(monkeypatch, tmp_path: Path) -
     out = catalog.index_new_sessions(return_details=True)
     assert len(out) == 1
     assert out[0].run_id == "run-cursor-1"
+
+
+def test_index_new_sessions_indexes_custom_project_folder(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """Custom projects are scanned directly without a platform adapter."""
+    traces = tmp_path / "clean-traces"
+    traces.mkdir()
+    trace_file = traces / "support-run.jsonl"
+    trace_file.write_text(
+        json.dumps(
+            {
+                "type": "user",
+                "message": {
+                    "role": "user",
+                    "content": "Support agent approved escalation.",
+                },
+                "timestamp": "2026-05-16T09:00:00Z",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    config_path = write_test_config(
+        tmp_path,
+        projects={"support": str(traces)},
+        project_types={"support": "custom"},
+    )
+    monkeypatch.setenv("LERIM_CONFIG", str(config_path))
+    reload_config()
+    monkeypatch.setattr(catalog.adapter_registry, "get_connected_agents", lambda _p: [])
+    monkeypatch.setattr(
+        catalog.adapter_registry, "get_connected_platform_paths", lambda _p: {}
+    )
+
+    out = catalog.index_new_sessions(return_details=True)
+
+    assert len(out) == 1
+    assert out[0].agent_type == "custom"
+    assert out[0].repo_path == str(traces.resolve())
+    assert out[0].session_path == str(trace_file.resolve())
+    assert fetch_session_doc(out[0].run_id)["agent_type"] == "custom"
 
 
 def test_index_new_sessions_marks_changed_when_known_hash_differs(

--- a/uv.lock
+++ b/uv.lock
@@ -2169,7 +2169,7 @@ wheels = [
 
 [[package]]
 name = "lerim"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "baml-py" },


### PR DESCRIPTION
## Summary
- add custom project source type via `lerim project add <path> --type custom`
- scan already-clean canonical JSONL folders directly as `agent_type=custom`, without platform adapters or compaction
- document the custom-agent flow, pasteable cleaner prompt, and per-agent architecture Mermaid diagrams
- bump package version and changelog for v0.2.1

## Validation
- `uv run ruff check src tests`
- `tests/run_tests.sh unit` -> 1457 passed
- `LERIM_INTEGRATION=1 uv run pytest tests/integration/custom_traces/test_cases.py -q` -> 1 passed
- `uv run --extra docs mkdocs build --strict --site-dir /tmp/lerim-docs-v021`
- `uv build` -> built `dist/lerim-0.2.1.tar.gz` and `dist/lerim-0.2.1-py3-none-any.whl`
