### PR TITLE
feat: quality loop (feedback + earned confidence) & safe provenance (redaction, provenance UI, skill-guard)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,38 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- Added a per-record feedback signal and earned confidence: a new `record_feedback`
+  table, a `confidence` column on `records`, and `ContextStore.record_feedback` /
+  `list_feedback`. Confidence is updated in place (not versioned) and never bumps the
+  index generation, so feedback stays cheap and does not churn FTS/embeddings.
+- Added the `lerim_context_feedback` MCP tool, a `lerim feedback <record_id>
+  <used|correct|wrong|confirm>` CLI command, and an `api_feedback` HTTP endpoint
+  (`POST/GET /api/records/{record_id}/feedback`). Feedback references existing records
+  only — it is not a `memory_save` primitive.
+- Earned confidence and recency now factor into hybrid retrieval ranking, so confirmed
+  records rise and repeatedly-wrong records fade. Added a relevance floor so retrieval
+  returns fewer or no results instead of padding out to `limit` with irrelevant matches.
+- Added automatic content-based secret/PII redaction at the ingestion edge
+  (`src/lerim/redaction.py`), applied in `write_session_cache` (all native adapters) and
+  `write_compact_trace` (generic-trace import) so secrets never reach records or skills.
+- Added dashboard feedback controls, real earned-confidence display, and a
+  provenance / proof-of-value view showing a record's source session and evidence.
+- Added `docs/contracts/feedback-and-confidence.md` documenting the feedback + confidence
+  JSON contracts across store, API, HTTP, CLI, and MCP.
+
+### Changed
+- Corrected the Reciprocal Rank Fusion constant from `RRF_K = 2` to the standard `60`,
+  so fused order reflects agreement between the semantic and lexical retrievers rather
+  than either retriever's noisy rank-1 pick.
+- Redaction is now automatic at the ingestion edge, building on the earlier manual
+  `scripts/redact_trace.py` helper.
+- Skill-stewardship validation now verifies that a proposal's cited evidence records
+  actually exist and that the proposed text is supported by them, and treats `AGENTS.md`
+  as a first-class instruction target when co-located with `SKILL.md`.
+
 ## [0.3.31] - 2026-06-21
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -227,6 +227,7 @@ Available MCP tools:
 - `lerim_context_answer`
 - `lerim_context_search`
 - `lerim_records_list`
+- `lerim_context_feedback`
 - `lerim_trace_submit`
 - `lerim_ingest_status`
 

--- a/dashboard/app/context/page.tsx
+++ b/dashboard/app/context/page.tsx
@@ -132,8 +132,8 @@ function ContextContent() {
 			setRecords(data.records);
 			setTotal(data.total);
 			setSelected((current) =>
-				current && data.records.some((record) => record.record_id === current.record_id)
-					? current
+				current
+					? data.records.find((record) => record.record_id === current.record_id) || null
 					: null,
 			);
 		} catch (err) {
@@ -351,7 +351,9 @@ function ContextContent() {
 													</span>
 												)}
 												{record.confidence != null && (
-													<span>{Math.round(record.confidence * 100)}%</span>
+													<span title="Feedback confidence: earned from recorded feedback signals">
+														Feedback {Math.round(record.confidence * 100)}%
+													</span>
 												)}
 											</div>
 										</button>
@@ -371,6 +373,7 @@ function ContextContent() {
 						<RecordEditor
 							key={selected.record_id}
 							record={selected}
+							onFeedbackSubmitted={load}
 						/>
 					) : (
 						<div className="flex h-full items-center justify-center rounded-lg border border-[var(--border)] bg-[var(--bg-subtle)]">
@@ -456,8 +459,8 @@ function HealthBanner({
 						{intel.record_stats.archived} archived
 					</span>
 					<Separator />
-					<span className="text-[var(--text-secondary)]">
-						avg: {intel.record_stats.avg_confidence.toFixed(2)}
+					<span className="text-[var(--text-secondary)]" title="Average earned feedback confidence across these records">
+						avg feedback confidence: {intel.record_stats.avg_confidence.toFixed(2)}
 					</span>
 				</div>
 

--- a/dashboard/components/GraphExplorer.tsx
+++ b/dashboard/components/GraphExplorer.tsx
@@ -1211,7 +1211,7 @@ function DetailsPanel({
       <div className="grid grid-cols-2 gap-3 text-xs">
         <Detail label="Kind" value={formatRecordKind(selection.node.record_kind)} />
         {nodeRole && <Detail label="Role" value={nodeRole} />}
-        <Detail label="Confidence" value={`${Math.round((selection.node.confidence || 0) * 100)}%`} />
+        <Detail label="Graph confidence" value={`${Math.round((selection.node.confidence || 0) * 100)}%`} />
         <Detail label="Status" value={selection.node.status || "active"} />
         <Detail label="Project" value={formatScopeLabel(selection.node.project)} />
       </div>

--- a/dashboard/components/RecordEditor.tsx
+++ b/dashboard/components/RecordEditor.tsx
@@ -1,12 +1,99 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { api } from "@/lib/api";
+import { useToast } from "@/components/Toast";
 import { formatRecordKind, formatRecordRole, formatScopeLabel, humanizeToken } from "@/lib/labels";
-import type { ContextRecord } from "@/lib/types";
+import type { ContextRecord, FeedbackSignal, RecordFeedbackEntry, RecordFeedbackResult } from "@/lib/types";
 
 interface RecordEditorProps {
   record: ContextRecord;
+  /** Called after a feedback signal is recorded, so a parent list/banner can refetch. */
+  onFeedbackSubmitted?: (result: RecordFeedbackResult) => void;
 }
 
-export default function RecordEditor({ record }: RecordEditorProps) {
+interface FeedbackAction {
+  signal: FeedbackSignal;
+  label: string;
+  hint: string;
+  tone: "positive" | "negative";
+}
+
+const FEEDBACK_ACTIONS: FeedbackAction[] = [
+  { signal: "used", label: "Used", hint: "Retrieved and used as-is (+0.05 confidence)", tone: "positive" },
+  { signal: "correct", label: "Correct", hint: "Verified correct (+0.15 confidence)", tone: "positive" },
+  { signal: "confirm", label: "Confirm", hint: "Independently re-confirmed (+0.15 confidence)", tone: "positive" },
+  { signal: "wrong", label: "Wrong", hint: "Verified wrong (-0.25 confidence)", tone: "negative" },
+];
+
+export default function RecordEditor({ record, onFeedbackSubmitted }: RecordEditorProps) {
+  const { addToast } = useToast();
   const rolePayload = parseRolePayload(record.role_payload);
+  const evidenceRefs = parseReferenceList(record.evidence_refs);
+  const sourceEventRefs = parseReferenceList(record.source_event_refs);
+
+  const [confidence, setConfidence] = useState(record.confidence);
+  const [entries, setEntries] = useState<RecordFeedbackEntry[]>([]);
+  const [entriesLoading, setEntriesLoading] = useState(true);
+  const [entriesError, setEntriesError] = useState<string | null>(null);
+  const [busySignal, setBusySignal] = useState<FeedbackSignal | null>(null);
+
+  /* Resync the displayed confidence whenever the parent hands us a fresh record
+     (e.g. after it refetches following a feedback submission). */
+  useEffect(() => {
+    setConfidence(record.confidence);
+  }, [record.record_id, record.confidence]);
+
+  /* Load feedback history for the selected record; degrade to an inline error
+     rather than throwing, since this is supplementary to the record itself. */
+  useEffect(() => {
+    let cancelled = false;
+    setEntriesLoading(true);
+    setEntriesError(null);
+    api
+      .getRecordFeedback(record.record_id)
+      .then((rows) => {
+        if (!cancelled) setEntries(rows);
+      })
+      .catch((err) => {
+        if (!cancelled) setEntriesError(err instanceof Error ? err.message : "Failed to load feedback history");
+      })
+      .finally(() => {
+        if (!cancelled) setEntriesLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [record.record_id]);
+
+  const submitFeedback = async (signal: FeedbackSignal) => {
+    setBusySignal(signal);
+    try {
+      const result = await api.recordFeedback(record.record_id, signal);
+      setConfidence(result.confidence);
+      setEntries((current) => [
+        ...current,
+        {
+          feedback_id: `pending-${Date.now()}`,
+          record_id: record.record_id,
+          signal: result.signal,
+          note: null,
+          source_session_id: null,
+          created_at: new Date().toISOString(),
+        },
+      ]);
+      addToast({ type: "success", message: `Feedback recorded: ${formatFeedbackSignal(signal)}` });
+      onFeedbackSubmitted?.(result);
+    } catch (err) {
+      addToast({ type: "error", message: err instanceof Error ? err.message : "Feedback failed" });
+    } finally {
+      setBusySignal(null);
+    }
+  };
+
+  const hasStaticProvenance = Boolean(record.source_session_id || evidenceRefs.length > 0 || sourceEventRefs.length > 0);
+  const showProvenanceEmptyState = !hasStaticProvenance && !entriesLoading && !entriesError && entries.length === 0;
+
   return (
     <div className="flex h-full flex-col rounded-lg border border-[var(--border)] bg-[var(--bg-subtle)]">
       <div className="flex items-center justify-between border-b border-[var(--border)] px-5 py-3">
@@ -69,7 +156,127 @@ export default function RecordEditor({ record }: RecordEditorProps) {
           <Field label="Created" value={record.created_at || "unknown"} />
           <Field label="Updated" value={record.updated_at || "unknown"} />
         </div>
+
+        {/* ---- Feedback confidence + verify controls ---- */}
+        <div className="rounded-md border border-[var(--border)] bg-[var(--bg-card)] px-3 py-3">
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <p className="text-xs font-medium text-[var(--text-secondary)]">Feedback confidence</p>
+            <ConfidenceMeter confidence={confidence} />
+          </div>
+          <p className="mt-1 text-[11px] text-[var(--text-muted)]">
+            Earned from recorded feedback signals below. Distinct from any relationship confidence shown in the graph
+            explorer.
+          </p>
+          <div className="mt-3 flex flex-wrap gap-2">
+            {FEEDBACK_ACTIONS.map((action) => (
+              <button
+                key={action.signal}
+                type="button"
+                title={action.hint}
+                onClick={() => submitFeedback(action.signal)}
+                disabled={busySignal !== null}
+                className={`min-h-9 rounded-md border px-3 text-xs font-medium outline-none transition-colors disabled:cursor-not-allowed disabled:opacity-50 focus-visible:ring-2 focus-visible:ring-[var(--accent-blue)] ${
+                  action.tone === "negative"
+                    ? "border-red-400/30 text-red-200 hover:bg-red-400/10"
+                    : "border-[var(--border)] text-[var(--text)] hover:bg-white/[0.05]"
+                }`}
+              >
+                {busySignal === action.signal ? "Saving…" : action.label}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* ---- Provenance / proof-of-value ---- */}
+        <div className="rounded-md border border-[var(--border)] bg-[var(--bg-card)] px-3 py-3">
+          <p className="text-xs font-medium text-[var(--text-secondary)]">Provenance</p>
+          {showProvenanceEmptyState ? (
+            <p className="mt-2 text-xs text-[var(--text-muted)]">
+              No source session, evidence, or feedback recorded for this record yet.
+            </p>
+          ) : (
+            <div className="mt-2 space-y-3">
+              <ProvenanceRow label="Source session" value={record.source_session_id} />
+              <ProvenanceList label="Evidence references" items={evidenceRefs} />
+              <ProvenanceList label="Source event references" items={sourceEventRefs} />
+
+              <div>
+                <p className="mb-1 text-[11px] font-medium text-[var(--text-muted)]">Feedback history</p>
+                {entriesLoading && <p className="text-xs text-[var(--text-muted)]">Loading…</p>}
+                {!entriesLoading && entriesError && (
+                  <p className="text-xs text-[var(--text-muted)]">Feedback history unavailable: {entriesError}</p>
+                )}
+                {!entriesLoading && !entriesError && entries.length === 0 && (
+                  <p className="text-xs text-[var(--text-muted)]">No feedback recorded yet.</p>
+                )}
+                {!entriesLoading && !entriesError && entries.length > 0 && (
+                  <ul className="space-y-1.5">
+                    {[...entries].reverse().map((entry) => (
+                      <li
+                        key={entry.feedback_id}
+                        className="flex flex-wrap items-center gap-2 rounded border border-[var(--border)] bg-black/10 px-2 py-1 text-[11px]"
+                      >
+                        <span className="rounded bg-white/[0.06] px-1.5 py-0.5 font-medium text-[var(--text)]">
+                          {formatFeedbackSignal(entry.signal)}
+                        </span>
+                        <span className="text-[var(--text-muted)]">{formatFeedbackTime(entry.created_at)}</span>
+                        {entry.source_session_id && (
+                          <span className="break-all font-mono text-[var(--text-muted)]">{entry.source_session_id}</span>
+                        )}
+                        {entry.note && <span className="w-full text-[var(--text-secondary)]">{entry.note}</span>}
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+            </div>
+          )}
+        </div>
       </div>
+    </div>
+  );
+}
+
+function ProvenanceRow({ label, value }: { label: string; value?: string | null }) {
+  if (!value) return null;
+  return (
+    <div>
+      <p className="mb-1 text-[11px] font-medium text-[var(--text-muted)]">{label}</p>
+      <p className="break-all font-mono text-xs text-[var(--text-secondary)]">{value}</p>
+    </div>
+  );
+}
+
+function ProvenanceList({ label, items }: { label: string; items: string[] }) {
+  if (items.length === 0) return null;
+  return (
+    <div>
+      <p className="mb-1 text-[11px] font-medium text-[var(--text-muted)]">{label}</p>
+      <ul className="space-y-1">
+        {items.map((item, index) => (
+          <li
+            key={`${index}:${item.slice(0, 24)}`}
+            className="whitespace-pre-wrap break-words text-xs text-[var(--text-secondary)]"
+          >
+            &ldquo;{item}&rdquo;
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function ConfidenceMeter({ confidence }: { confidence: number | null }) {
+  if (confidence == null) {
+    return <span className="text-xs text-[var(--text-muted)]">{"—"}</span>;
+  }
+  const pct = Math.round(Math.max(0, Math.min(1, confidence)) * 100);
+  return (
+    <div className="flex items-center gap-2">
+      <div className="h-1.5 w-20 overflow-hidden rounded-full bg-white/[0.06]">
+        <div className="h-full rounded-full bg-[var(--accent-teal)]" style={{ width: `${pct}%` }} />
+      </div>
+      <span className="text-xs tabular-nums text-[var(--text)]">{pct}%</span>
     </div>
   );
 }
@@ -90,6 +297,42 @@ function renderPayloadValue(value: unknown): string {
   if (Array.isArray(value)) return value.map(renderPayloadValue).join("\n");
   if (value && typeof value === "object") return JSON.stringify(value, null, 2);
   return String(value ?? "");
+}
+
+/** Parse a compact-JSON reference list (`evidence_refs`/`source_event_refs`); tolerate plain text. */
+function parseReferenceList(value?: string | null): string[] {
+  const text = value?.trim();
+  if (!text) return [];
+  try {
+    const parsed = JSON.parse(text) as unknown;
+    if (Array.isArray(parsed)) {
+      return parsed.map((item) => String(item).trim()).filter(Boolean);
+    }
+    return [String(parsed)];
+  } catch {
+    return [text];
+  }
+}
+
+function formatFeedbackSignal(signal: string): string {
+  const labels: Record<string, string> = {
+    used: "Used",
+    correct: "Correct",
+    wrong: "Wrong",
+    confirm: "Confirmed",
+  };
+  return labels[signal] || humanizeToken(signal);
+}
+
+function formatFeedbackTime(iso: string): string {
+  const parsed = new Date(iso);
+  if (Number.isNaN(parsed.getTime())) return iso || "unknown";
+  return parsed.toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
 }
 
 function Field({ label, value }: { label: string; value: string }) {

--- a/dashboard/components/RecordList.tsx
+++ b/dashboard/components/RecordList.tsx
@@ -43,7 +43,9 @@ export default function RecordList({ records }: RecordListProps) {
               </span>
             )}
             {m.record_kind !== "summary" && (
-              <span>Confidence: {m.confidence != null ? `${Math.round(m.confidence * 100)}%` : "\u2014"}</span>
+              <span title="Feedback confidence: earned from recorded feedback signals">
+                Feedback confidence: {m.confidence != null ? `${Math.round(m.confidence * 100)}%` : "\u2014"}
+              </span>
             )}
             <span>{m.created_at ? formatDate(m.created_at) : "\u2014"}</span>
           </div>

--- a/dashboard/lib/api.ts
+++ b/dashboard/lib/api.ts
@@ -2,6 +2,7 @@ import type {
   ActivityFeedResponse,
   ContextRecord,
   ContextRecordVersion,
+  FeedbackSignal,
   GraphQueryResponse,
   IntelligenceResponse,
   LiveStatusResponse,
@@ -11,6 +12,8 @@ import type {
   PipelineReportResponse,
   PipelineStatusResponse,
   ProjectSummary,
+  RecordFeedbackEntry,
+  RecordFeedbackResult,
   RecordFiltersResponse,
   RecordVersionsResponse,
   RecordsResponse,
@@ -102,7 +105,7 @@ function normalizeRecord(row: Record<string, unknown>): ContextRecord {
     role_payload: asNullableString(row.role_payload),
     project,
     tags: [],
-    confidence: null,
+    confidence: asNullableNumber(row.confidence),
     status: String(row.status || "active"),
     source: asNullableString(row.source_name),
     source_session_id: asNullableString(row.source_session_id),
@@ -138,6 +141,27 @@ function normalizeRecordVersion(row: Record<string, unknown>): ContextRecordVers
     changed_at: String(row.changed_at || row.updated_at || row.created_at || ""),
     changed_by_session_id: asNullableString(row.changed_by_session_id),
   };
+}
+
+/** Normalize one feedback row from `GET /api/records/{id}/feedback`. */
+function normalizeFeedbackEntry(row: Record<string, unknown>): RecordFeedbackEntry {
+  return {
+    feedback_id: String(row.feedback_id || ""),
+    record_id: String(row.record_id || ""),
+    signal: String(row.signal || ""),
+    note: asNullableString(row.note),
+    source_session_id: asNullableString(row.source_session_id),
+    created_at: String(row.created_at || ""),
+  };
+}
+
+/** Average `confidence` across records that carry one, or 0 when none do. */
+function averageConfidence(records: ContextRecord[]): number {
+  const values = records
+    .map((record) => record.confidence)
+    .filter((value): value is number => value != null);
+  if (values.length === 0) return 0;
+  return values.reduce((sum, value) => sum + value, 0) / values.length;
 }
 
 function normalizeStats(raw: Record<string, unknown>): StatsResponse {
@@ -418,7 +442,7 @@ function normalizeIntelligence(status: Record<string, unknown>, records: Context
       total: records.length,
       active,
       archived,
-      avg_confidence: 0,
+      avg_confidence: averageConfidence(records),
       stale_count: 0,
     },
     signals: [],
@@ -601,6 +625,20 @@ export const api = {
     );
     assertRecordsProjectScope(project, [record]);
     return record;
+  },
+
+  /** Record one feedback signal against a record; returns its recomputed confidence. */
+  recordFeedback: async (recordId: string, signal: FeedbackSignal, note?: string) => {
+    return apiFetch<RecordFeedbackResult>(`/api/records/${encodeURIComponent(recordId)}/feedback`, {
+      method: "POST",
+      body: JSON.stringify({ signal, note: note?.trim() || undefined }),
+    });
+  },
+
+  /** Fetch the feedback history (oldest first) recorded against one record. */
+  getRecordFeedback: async (recordId: string): Promise<RecordFeedbackEntry[]> => {
+    const raw = await apiFetch<Record<string, unknown>>(`/api/records/${encodeURIComponent(recordId)}/feedback`);
+    return arrayValue(raw.rows).map((row) => normalizeFeedbackEntry(objectValue(row)));
   },
 
   getSkillTargets: async (): Promise<SkillTargetsResponse> => {

--- a/dashboard/lib/types.ts
+++ b/dashboard/lib/types.ts
@@ -165,6 +165,28 @@ export interface RecordFiltersResponse {
   projects: string[];
 }
 
+/* ----- Record Feedback (docs/contracts/feedback-and-confidence.md) --- */
+
+/** Canonical feedback signals accepted by `POST /api/records/{id}/feedback`. */
+export type FeedbackSignal = "used" | "correct" | "wrong" | "confirm";
+
+/** One row from `GET /api/records/{id}/feedback`. */
+export interface RecordFeedbackEntry {
+  feedback_id: string;
+  record_id: string;
+  signal: string;
+  note: string | null;
+  source_session_id: string | null;
+  created_at: string;
+}
+
+/** Result payload from `POST /api/records/{id}/feedback`. */
+export interface RecordFeedbackResult {
+  record_id: string;
+  confidence: number;
+  signal: string;
+}
+
 /* ----- Skill Stewardship --------------------------------------------- */
 
 export interface SkillTargetFile {

--- a/docs/contracts/feedback-and-confidence.md
+++ b/docs/contracts/feedback-and-confidence.md
@@ -1,0 +1,250 @@
+# Feedback and Confidence Contract
+
+This is the durable contract for the per-record feedback signal and the earned
+per-record confidence score. Retrieval and dashboard lanes should read from
+this document instead of re-deriving these shapes from `store.py`.
+
+## Summary
+
+Every context record now carries an earned `confidence` score in `[0.0, 1.0]`.
+Confidence starts at `0.5` for every record and moves only when a caller
+records an explicit feedback signal through `ContextStore.record_feedback`.
+Feedback is intentionally a separate axis from record content:
+
+- recording feedback never edits `title`/`body`/`status`/etc.
+- recording feedback never creates a `record_versions` row.
+- recording feedback never bumps the records index generation (it does not
+  touch FTS or embeddings).
+- editing record content (`update_record`, `archive_record`, `supersede_record`)
+  never changes `confidence`.
+
+## Data model
+
+### `records.confidence`
+
+```
+confidence REAL NOT NULL DEFAULT 0.5
+```
+
+Added via migration (`ContextStore._ensure_record_confidence_schema`) to the
+`records` table only. `record_versions` does **not** have a `confidence`
+column — confidence is not versioned, so version rows always report the
+default `0.5` when read back through `_record_row_to_dict`.
+
+### `record_feedback` table
+
+```
+CREATE TABLE record_feedback (
+    feedback_id TEXT PRIMARY KEY,
+    record_id TEXT NOT NULL,
+    signal TEXT NOT NULL,
+    note TEXT,
+    source_session_id TEXT,
+    created_at TEXT NOT NULL
+);
+```
+
+One row per feedback event. Indexed on `record_id`. There is no foreign key
+from `record_feedback.record_id` to `records.record_id` — this keeps
+`reset_project_memory`/`count_project_memory` (which delete/count `records`
+without first deleting `record_feedback`) from raising foreign-key errors.
+
+## Record JSON shape
+
+Every record dict returned by the store (`fetch_record`, `query`, search hits
+via `_record_row_to_dict`) now includes:
+
+```json
+{
+  "record_id": "rec_...",
+  "...": "... existing fields unchanged ...",
+  "confidence": 0.5
+}
+```
+
+- Type: `float`, range `[0.0, 1.0]`. A record whose confidence has been driven
+  all the way down to `0.0` (or up to `1.0`) by feedback reads back as that
+  real value everywhere — `_record_row_to_dict` distinguishes "column absent"
+  (pre-migration row) from "value is a genuine `0.0`" by checking `is None`,
+  not by falling back on `... or DEFAULT_RECORD_CONFIDENCE` (that pattern
+  would treat an earned `0.0` as missing and silently report `0.5` instead;
+  `record_feedback`'s own current-confidence read applies the same `is None`
+  guard, so a *subsequent* feedback call after reaching `0.0` recomputes its
+  delta from the true floor, not a phantom `0.5`).
+- Default: `0.5` for every record that has never received feedback, and for
+  any row read before the column existed (`_row_value` returns `None` when
+  the column is absent, which maps to `DEFAULT_RECORD_CONFIDENCE`).
+- This field flows through every reader unchanged: CLI `lerim query records
+  list`/`lerim context records`, the HTTP `/api/query` and `/api/records/{id}`
+  routes, the `lerim_records_list`/`lerim_context_search` MCP tools, and the
+  cloud shipper's context-record export.
+
+## Feedback signal enum
+
+Canonical values (`lerim.context.spec.FeedbackSignal` /
+`ALLOWED_FEEDBACK_SIGNALS`):
+
+| Signal    | Meaning                                   | Confidence delta |
+|-----------|--------------------------------------------|------------------|
+| `used`    | The record was retrieved and used as-is    | `+0.05`          |
+| `correct` | The record's content was verified correct  | `+0.15`          |
+| `confirm` | An independent pass re-confirmed the record | `+0.15`         |
+| `wrong`   | The record's content was verified wrong    | `-0.25`          |
+
+Any other value raises `ValueError("invalid_feedback_signal:<value>")`.
+
+### Confidence update rule
+
+Deterministic and bounded — no LLM involved:
+
+```
+next_confidence = clamp(current_confidence + delta[signal], 0.0, 1.0)
+```
+
+Implemented in `lerim.context.spec.next_record_confidence(current, signal)`.
+
+## Store API
+
+### `ContextStore.record_feedback(record_id, signal, *, note=None, source_session_id=None) -> dict`
+
+1. Raises `ValueError("invalid_feedback_signal:<value>")` if `signal` is not
+   one of the four allowed values.
+2. Opens one `BEGIN IMMEDIATE` transaction and, on that same connection, reads
+   `records.confidence` for `record_id`; raises
+   `ValueError("record_not_found:<record_id>")` if no row matches. The read
+   happens inside this locked transaction (not via a separate `fetch_record()`
+   call beforehand) so two concurrent `record_feedback` calls for the same
+   `record_id` cannot both read the same stale confidence and have the second
+   writer silently clobber the first.
+3. In that same transaction: inserts a `record_feedback` row, then runs
+   `UPDATE records SET confidence = ? WHERE record_id = ?` with the recomputed
+   value. Does not call `_insert_record_version` or
+   `_bump_records_index_generation`.
+4. Returns:
+
+```json
+{"record_id": "rec_...", "confidence": 0.65, "signal": "correct"}
+```
+
+### `ContextStore.list_feedback(record_id) -> list[dict]`
+
+Returns every feedback row for one record, oldest first, exportable for
+offline/private evals:
+
+```json
+[
+  {
+    "feedback_id": "fb_...",
+    "record_id": "rec_...",
+    "signal": "correct",
+    "note": "Confirmed in prod incident review",
+    "source_session_id": "sess_...",
+    "created_at": "2026-07-16T00:00:00+00:00"
+  }
+]
+```
+
+## Server API (`lerim.server.api`)
+
+### `api_feedback(record_id, signal, *, note=None, source_session_id=None, scope="all", project=None) -> dict`
+
+Scope resolution mirrors `api_query`: `project`/`scope` are resolved through
+`_resolve_selected_projects` purely to validate the `project` token and to
+populate `projects_used`/`scope` in the response — `record_id` is a global
+identifier, so the underlying store call is not project-filtered.
+
+> **Known gap, pending a product decision:** this means any caller can submit
+> feedback against any `record_id` in the entire global `context.sqlite3`, in
+> any project, regardless of the `scope`/`project` value supplied. In
+> practice this is currently unreachable through real entry points — the CLI
+> `feedback` subcommand, the `lerim_context_feedback` MCP tool, and the HTTP
+> `POST /api/records/{id}/feedback` body handler have no `project`/`scope`
+> parameter, so every real caller uses the defaults (`scope="all"`,
+> `project=None`). Two ways to close this, neither applied yet: (a) accept
+> global-scope feedback as intentional (record ids are unguessable UUIDs) and
+> drop this unused scope/project machinery from `api_feedback`, or (b) thread
+> `project_ids` through `record_feedback`/`fetch_record` to actually enforce
+> scope *and* expose `--project`/`scope` consistently at the CLI/MCP/HTTP
+> layers so the enforcement is reachable and callers have a way to satisfy
+> it. Do not implement half of (b) (store/api enforcement without CLI/MCP/HTTP
+> exposure): with today's default `scope="all"`, that would silently resolve
+> to "all currently-registered projects in the local config" and reject
+> feedback for any record whose project is not currently registered locally,
+> with no override available to callers.
+
+Success:
+
+```json
+{
+  "record_id": "rec_...",
+  "confidence": 0.65,
+  "signal": "correct",
+  "error": false,
+  "projects_used": [],
+  "scope": "all"
+}
+```
+
+Failure shapes (same convention as `api_query`):
+
+```json
+{"error": true, "message": "Project not found: bogus", "projects_used": []}
+{"error": true, "message": "invalid_feedback_signal:bogus", "projects_used": [], "status_code": 400}
+{"error": true, "message": "record_not_found:rec_missing", "projects_used": [], "status_code": 400}
+{"error": true, "message": "Context query storage is unavailable.", "projects_used": [], "status_code": 503}
+```
+
+### `api_feedback_list(record_id) -> dict`
+
+```json
+{"record_id": "rec_...", "rows": [...], "count": 1, "error": false}
+```
+
+or `{"error": true, "message": "Context query storage is unavailable.", "status_code": 503}`.
+
+## HTTP endpoint
+
+### `POST /api/records/{record_id}/feedback`
+
+Request body:
+
+```json
+{
+  "signal": "correct",
+  "note": "optional free text",
+  "source_session_id": "optional session id"
+}
+```
+
+`signal` is required (400 `Missing 'signal'` if blank). Response body is the
+`api_feedback(...)` payload (200 on success). Errors from `api_feedback` map
+`status_code` (400/503) onto the HTTP response status.
+
+### `GET /api/records/{record_id}/feedback`
+
+Response body is the `api_feedback_list(record_id)` payload (200 on success,
+503 if the context store is unavailable).
+
+## CLI
+
+```
+lerim feedback <record_id> <used|correct|wrong|confirm> [--note TEXT] [--json]
+```
+
+- `record_id` and `signal` are positional; `signal` is argparse-validated
+  against `ALLOWED_FEEDBACK_SIGNALS`.
+- `--json` prints the `api_feedback(...)` payload as JSON and exits `1` when
+  `error` is `true`.
+- Without `--json`, a failure prints `message` to stderr and exits `1`;
+  success prints the JSON payload to stdout and exits `0`.
+
+## MCP tool
+
+### `lerim_context_feedback(record_id, signal, note=None, source_session_id=None) -> dict`
+
+Registered immediately after `lerim_records_list`. This is **not** a
+memory-save tool — `record_id` must reference a record that already exists;
+it never creates new durable context. Blank `record_id`/`signal` are rejected
+locally (`{"error": true, "message": "record_id_required"}` /
+`{"error": true, "message": "signal_required"}`) before reaching the store;
+all other validation/error shapes match `api_feedback(...)` above.

--- a/src/lerim/adapters/common.py
+++ b/src/lerim/adapters/common.py
@@ -11,6 +11,8 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Any
 
+from lerim.redaction import redact_text
+
 
 def parse_timestamp(value: Any) -> datetime | None:
     """Parse many timestamp shapes into a timezone-aware UTC datetime."""
@@ -181,11 +183,12 @@ def write_session_cache(
     lines: list[str],
     compact_fn: Callable[[str], str],
 ) -> Path:
-    """Write compacted session JSONL to cache directory and return the path."""
+    """Write compacted, secret-redacted session JSONL to cache directory and return the path."""
     cache_dir.mkdir(parents=True, exist_ok=True)
     cache_path = cache_dir / f"{run_id}.jsonl"
     raw = "\n".join(lines) + "\n"
-    cache_path.write_text(compact_fn(raw), encoding="utf-8")
+    compacted = compact_fn(raw)
+    cache_path.write_text(redact_text(compacted), encoding="utf-8")
     return cache_path
 
 

--- a/src/lerim/cloud/shipper.py
+++ b/src/lerim/cloud/shipper.py
@@ -711,7 +711,7 @@ def _query_context_records(
         "SELECT r.record_id, r.project_id, r.kind, r.title, r.body, r.status, "
         "r.created_at, r.updated_at, r.valid_from, r.valid_until, "
         "r.source_session_id, r.decision, r.why, r.alternatives, r.consequences, "
-        "r.user_intent, r.what_happened, r.outcomes, "
+        "r.user_intent, r.what_happened, r.outcomes, r.confidence, "
         "s.agent_type AS ingestion_agent, s.source_trace_ref AS source_trace_ref, "
         "COALESCE(rv.changed_by_session_id, r.source_session_id) AS changed_by_session_id, "
         "COALESCE(rv.change_reason, rv.change_kind) AS change_reason "

--- a/src/lerim/context/retrieval.py
+++ b/src/lerim/context/retrieval.py
@@ -4,16 +4,99 @@ from __future__ import annotations
 
 import sqlite3
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from typing import Any
 
 import sqlite_vec
 
 from lerim.config.settings import get_config
 from lerim.context.roles import DEFAULT_RECORD_ROLE
+from lerim.context.spec import DEFAULT_RECORD_CONFIDENCE
 
-RRF_K = 2
+RRF_K = 60
+"""Reciprocal Rank Fusion damping constant.
+
+Standard RRF practice (Cormack, Clarke & Buettcher, 2009) uses K=60: large enough
+that the score gap between adjacent top ranks stays gentle (1/61 vs 1/62, about a
+1.6% step), so the fused order reflects broad agreement between the semantic and
+lexical retrievers rather than one retriever's noisy rank-1 pick. The previous
+K=2 made that same step (1/3 vs 1/4, a 33% jump) so steep that whichever
+retriever happened to rank a record #1 could dominate the fused order on its own.
+"""
 DEFAULT_SEMANTIC_RRF_WEIGHT = 0.7
 DEFAULT_LEXICAL_RRF_WEIGHT = 0.3
+
+CONFIDENCE_MULTIPLIER_FLOOR = 0.5
+CONFIDENCE_MULTIPLIER_CEILING = 1.5
+"""Bounds of the earned-confidence multiplier applied to a fused RRF score.
+
+Confidence lives in [0, 1] with a neutral default of 0.5 (see
+lerim.context.spec.DEFAULT_RECORD_CONFIDENCE). Mapping confidence linearly onto
+[0.5, 1.5] means a record at the default confidence leaves its fused score
+unchanged (multiplier 1.0), a fully-confirmed record (confidence 1.0) is boosted
+up to 1.5x, and a record repeatedly marked wrong (confidence 0.0) is discounted
+to 0.5x. Confidence can therefore reorder close matches but cannot, by itself,
+zero out or invert a materially stronger rank signal.
+"""
+
+RECENCY_BOOST_WEIGHT = 0.1
+"""Mild recency boost, capped at +/-10% of a candidate's fused score.
+
+Recency is normalized *within one query's fused candidates* (the newest
+candidate gets the full +RECENCY_BOOST_WEIGHT, the oldest the full
+-RECENCY_BOOST_WEIGHT) rather than compared against wall-clock age. That keeps
+the boost meaningful whether the whole corpus is a day old or a year old. It is
+intentionally small so it only nudges close ties toward the newer record.
+"""
+
+RELEVANCE_FLOOR_REFERENCE_RANK = 40
+"""Shortlist depth used only to calibrate RELEVANCE_FLOOR, not a query limit.
+
+Matches the shipped default `semantic_shortlist_size` / `lexical_shortlist_size`
+(config/default.toml). `search_records` fetches at least this many candidates
+per retriever for the shipped default query `limit` of 8 (it requests
+`max(limit * 3, shortlist_size)`); a larger caller-supplied `limit`, or extra
+kind/role/status/valid_at filters, only deepens the real shortlist further.
+Calibrating against this realistic depth -- rather than an idealized rank-1
+candidate -- is what gives RELEVANCE_FLOOR real teeth. See RELEVANCE_FLOOR.
+"""
+
+RELEVANCE_FLOOR_SAFETY_MARGIN = 1.25
+"""Multiplier over the worst-case score RELEVANCE_FLOOR is calibrated against,
+so that exact worst case lands strictly under the floor rather than exactly on
+the (inclusive) boundary.
+"""
+
+RELEVANCE_FLOOR = RELEVANCE_FLOOR_SAFETY_MARGIN * (
+    DEFAULT_SEMANTIC_RRF_WEIGHT
+    / (RRF_K + RELEVANCE_FLOOR_REFERENCE_RANK)
+    * CONFIDENCE_MULTIPLIER_FLOOR
+    * (1.0 - RECENCY_BOOST_WEIGHT)
+)
+"""Minimum blended (RRF x confidence x recency) score required to appear at all.
+
+Nearest-neighbor search always returns *something*, however distant from the
+query, so without a floor `search_records` would keep padding results out to
+`limit` with candidates nobody actually wants. When no fused candidate clears
+this conservative bar, `search_records` returns fewer results, or none, instead
+of forcing top-k.
+
+Calibrated against the weakest realistic survivor of a full shortlist: a
+candidate ranked dead last (RELEVANCE_FLOOR_REFERENCE_RANK) in only the
+higher-weighted retriever (DEFAULT_SEMANTIC_RRF_WEIGHT -- the harder of the two
+retrievers to exclude, since it counts for more) that has also been repeatedly
+marked wrong (confidence at CONFIDENCE_MULTIPLIER_FLOOR) and is the most stale
+record in its batch (recency at its floor multiplier). An earlier version of
+this floor was set as a small fraction (5%) of an idealized rank-1-in-both
+ceiling instead; because RRF's rank-based score decays gently by design (see
+RRF_K), that ceiling was so much larger than realistic shortlist-tail scores
+that the floor could never actually exclude anything reachable at the shipped
+default shortlist depth, no matter how weak, unconfirmed, or stale. A
+candidate that is merely unconfirmed (default confidence) or merely old, but
+not both weak-ranked and actively discredited/stale, still clears this floor
+comfortably -- see TestRelevanceFloorAtRealisticShortlistDepth in
+test_retrieval.py.
+"""
 
 
 @dataclass(frozen=True)
@@ -41,6 +124,7 @@ class SearchHit:
     outcomes: str | None = None
     record_role: str = DEFAULT_RECORD_ROLE
     role_payload: str | None = None
+    confidence: float = DEFAULT_RECORD_CONFIDENCE
 
 
 def search_records(
@@ -55,7 +139,16 @@ def search_records(
     include_archived: bool = False,
     limit: int = 8,
 ) -> list[SearchHit]:
-    """Run hybrid retrieval over records for one context store."""
+    """Run hybrid retrieval over records for one context store.
+
+    Candidate metadata (confidence, updated_at) is fetched for the FULL fused
+    candidate set before any `limit` slicing happens, so blend_confidence_and_recency
+    and apply_relevance_floor can rerank -- and trim -- the whole set first.
+    Recency uses `updated_at` rather than `valid_from`: record_feedback (earned
+    confidence) intentionally leaves `updated_at` untouched, so it stays a clean
+    signal of when the record's own content last changed, independent of
+    confidence, rather than of when it first became true.
+    """
     config = get_config()
     with store.connect() as conn:
         fts_available = True
@@ -104,15 +197,29 @@ def search_records(
         )
         if not combined:
             return []
-        top_ids = [record_id for record_id, _score, _sources in combined[:limit]]
-        placeholders = ", ".join("?" for _ in top_ids)
+        # Fetch metadata for every fused candidate (not just the top `limit`) so
+        # reranking below sees the full picture before anything is sliced away.
+        candidate_ids = [record_id for record_id, _score, _sources in combined]
+        placeholders = ", ".join("?" for _ in candidate_ids)
         rows = conn.execute(
             f"SELECT * FROM records WHERE record_id IN ({placeholders})",
-            tuple(top_ids),
+            tuple(candidate_ids),
         ).fetchall()
     row_map = {str(row["record_id"]): row for row in rows}
+    confidence_by_id = {
+        record_id: float(row["confidence"]) for record_id, row in row_map.items()
+    }
+    updated_at_by_id = {
+        record_id: str(row["updated_at"]) for record_id, row in row_map.items()
+    }
+    reranked = blend_confidence_and_recency(
+        combined,
+        confidence_by_id=confidence_by_id,
+        updated_at_by_id=updated_at_by_id,
+    )
+    reranked = apply_relevance_floor(reranked)
     hits: list[SearchHit] = []
-    for record_id, score, sources in combined:
+    for record_id, score, sources in reranked:
         row = row_map.get(record_id)
         if row is None:
             continue
@@ -138,6 +245,7 @@ def search_records(
                 valid_from=str(row["valid_from"]),
                 valid_until=row["valid_until"],
                 score=score,
+                confidence=confidence_by_id.get(record_id, DEFAULT_RECORD_CONFIDENCE),
                 sources=sources,
             )
         )
@@ -300,6 +408,109 @@ def rrf_fuse(
     ]
     combined.sort(key=lambda item: item[1], reverse=True)
     return combined
+
+
+def blend_confidence_and_recency(
+    combined: list[tuple[str, float, list[str]]],
+    *,
+    confidence_by_id: dict[str, float],
+    updated_at_by_id: dict[str, str],
+) -> list[tuple[str, float, list[str]]]:
+    """Rerank fused RRF candidates by folding in earned confidence and recency.
+
+    Call this over the FULL fused candidate set, before any `limit` slicing, so a
+    lower-ranked but well-confirmed, recently-touched record can out-rank a
+    higher-ranked one that has been discredited or gone stale. Each fused RRF
+    score is scaled by a confidence multiplier (CONFIDENCE_MULTIPLIER_FLOOR..
+    CONFIDENCE_MULTIPLIER_CEILING) and a mild, batch-relative recency multiplier
+    (+/-RECENCY_BOOST_WEIGHT), then the list is re-sorted descending. A candidate
+    missing from either metadata map is treated as neutral rather than penalized.
+    """
+    recency_multipliers = _recency_multipliers(updated_at_by_id)
+    blended = [
+        (
+            record_id,
+            rrf_score
+            * _confidence_multiplier(confidence_by_id.get(record_id, DEFAULT_RECORD_CONFIDENCE))
+            * recency_multipliers.get(record_id, 1.0),
+            sources,
+        )
+        for record_id, rrf_score, sources in combined
+    ]
+    blended.sort(key=lambda item: item[1], reverse=True)
+    return blended
+
+
+def apply_relevance_floor(
+    reranked: list[tuple[str, float, list[str]]],
+) -> list[tuple[str, float, list[str]]]:
+    """Drop candidates whose blended score falls below RELEVANCE_FLOOR.
+
+    Nearest-neighbor search always returns *something*, however distant from the
+    query, so without this floor a caller would keep receiving `limit` results
+    even when nothing in the fused set is a real match. Keeps the (already
+    descending) ordering of whatever survives.
+    """
+    return [item for item in reranked if item[1] >= RELEVANCE_FLOOR]
+
+
+def _confidence_multiplier(confidence: float) -> float:
+    """Map earned confidence in [0, 1] onto the confidence score multiplier.
+
+    Confidence is clamped defensively before scaling, so a caller passing an
+    out-of-range value degrades to the nearest valid bound instead of inverting
+    the ranking.
+    """
+    clamped = max(0.0, min(1.0, float(confidence)))
+    span = CONFIDENCE_MULTIPLIER_CEILING - CONFIDENCE_MULTIPLIER_FLOOR
+    return CONFIDENCE_MULTIPLIER_FLOOR + clamped * span
+
+
+def _recency_multipliers(updated_at_by_id: dict[str, str]) -> dict[str, float]:
+    """Return a mild, batch-relative recency multiplier per candidate.
+
+    Recency is normalized against the *other fused candidates in this query*
+    (the newest gets the full +RECENCY_BOOST_WEIGHT, the oldest the full
+    -RECENCY_BOOST_WEIGHT) rather than against wall-clock age, so the boost
+    stays meaningful whether the whole corpus is a day old or a year old.
+    Candidates with an unparseable timestamp, and batches with fewer than two
+    distinct parseable timestamps to compare, are left neutral (multiplier 1.0).
+    """
+    parsed: dict[str, datetime] = {}
+    for record_id, raw in updated_at_by_id.items():
+        parsed_ts = _parse_utc_timestamp(raw)
+        if parsed_ts is not None:
+            parsed[record_id] = parsed_ts
+    multipliers = dict.fromkeys(updated_at_by_id, 1.0)
+    if len(parsed) < 2:
+        return multipliers
+    oldest = min(parsed.values())
+    newest = max(parsed.values())
+    span_seconds = (newest - oldest).total_seconds()
+    if span_seconds <= 0:
+        return multipliers
+    for record_id, timestamp in parsed.items():
+        fraction = (timestamp - oldest).total_seconds() / span_seconds
+        multipliers[record_id] = 1.0 + RECENCY_BOOST_WEIGHT * (2 * fraction - 1)
+    return multipliers
+
+
+def _parse_utc_timestamp(raw: str | None) -> datetime | None:
+    """Parse one ISO-8601 timestamp into an aware UTC datetime, or None.
+
+    Recency is an advisory ranking input, so a timestamp that fails to parse is
+    simply excluded from the recency comparison rather than raising.
+    """
+    text = str(raw or "").strip()
+    if not text:
+        return None
+    try:
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
 
 
 def compile_safe_fts_query(raw: str) -> str | None:

--- a/src/lerim/context/spec.py
+++ b/src/lerim/context/spec.py
@@ -43,10 +43,27 @@ class RecordChangeKind(StrEnum):
     SUPERSEDE = "supersede"
 
 
+class FeedbackSignal(StrEnum):
+    """Canonical per-record feedback signals that earn or spend confidence."""
+
+    USED = "used"
+    CORRECT = "correct"
+    WRONG = "wrong"
+    CONFIRM = "confirm"
+
+
 ALLOWED_KINDS = tuple(kind.value for kind in RecordKind)
 ALLOWED_STATUSES = tuple(status.value for status in RecordStatus)
 ALLOWED_CHANGE_KINDS = tuple(change_kind.value for change_kind in RecordChangeKind)
 ALLOWED_ROLES = ALLOWED_RECORD_ROLES
+ALLOWED_FEEDBACK_SIGNALS = tuple(signal.value for signal in FeedbackSignal)
+DEFAULT_RECORD_CONFIDENCE = 0.5
+FEEDBACK_CONFIDENCE_DELTAS: dict[str, float] = {
+    FeedbackSignal.CORRECT.value: 0.15,
+    FeedbackSignal.CONFIRM.value: 0.15,
+    FeedbackSignal.USED.value: 0.05,
+    FeedbackSignal.WRONG.value: -0.25,
+}
 MAX_RECORD_TITLE_CHARS = 120
 MAX_EPISODE_BODY_CHARS = 1200
 MAX_DURABLE_BODY_CHARS = 850
@@ -200,6 +217,22 @@ def normalize_record_kind(value: Any) -> str:
 def normalize_record_status(value: Any, default: str = "active") -> str:
     """Normalize one record status candidate."""
     return str(value or default).strip().lower()
+
+
+def normalize_feedback_signal(value: Any) -> str:
+    """Return a canonical per-record feedback signal or raise ValueError."""
+    text = str(value or "").strip().lower()
+    if text not in ALLOWED_FEEDBACK_SIGNALS:
+        raise ValueError(f"invalid_feedback_signal:{value}")
+    return text
+
+
+def next_record_confidence(current: Any, signal: str) -> float:
+    """Return the next clamped [0, 1] confidence after one feedback signal."""
+    normalized_signal = normalize_feedback_signal(signal)
+    delta = FEEDBACK_CONFIDENCE_DELTAS[normalized_signal]
+    current_value = float(current if current is not None else DEFAULT_RECORD_CONFIDENCE)
+    return max(0.0, min(1.0, current_value + delta))
 
 
 def format_durable_record_kinds() -> str:

--- a/src/lerim/context/store.py
+++ b/src/lerim/context/store.py
@@ -31,7 +31,10 @@ from lerim.context.query_spec import (
 import lerim.context.retrieval as retrieval
 from lerim.context.spec import (
     ALLOWED_CHANGE_KINDS,
+    DEFAULT_RECORD_CONFIDENCE,
     DEFAULT_RECORD_ROLE,
+    next_record_confidence,
+    normalize_feedback_signal,
     normalize_record_payload,
     record_search_text,
 )
@@ -370,6 +373,15 @@ class ContextStore:
                     UNIQUE(project_id, source_node_id, target_node_id, relation_kind)
                 );
 
+                CREATE TABLE IF NOT EXISTS record_feedback (
+                    feedback_id TEXT PRIMARY KEY,
+                    record_id TEXT NOT NULL,
+                    signal TEXT NOT NULL,
+                    note TEXT,
+                    source_session_id TEXT,
+                    created_at TEXT NOT NULL
+                );
+
                 CREATE VIRTUAL TABLE IF NOT EXISTS records_fts USING fts5(
                     record_id UNINDEXED,
                     project_id UNINDEXED,
@@ -393,6 +405,7 @@ class ContextStore:
             self._ensure_record_reference_schema(conn)
             self._ensure_record_index_text_schema(conn)
             self._ensure_record_role_schema(conn)
+            self._ensure_record_confidence_schema(conn)
             self._ensure_secondary_indexes(conn)
             self._validate_schema(conn)
             conn.execute(
@@ -475,6 +488,7 @@ class ContextStore:
             CREATE INDEX IF NOT EXISTS idx_records_source_session_id ON records(source_session_id);
             CREATE INDEX IF NOT EXISTS idx_record_versions_record_id ON record_versions(record_id);
             CREATE INDEX IF NOT EXISTS idx_record_versions_changed_at ON record_versions(changed_at);
+            CREATE INDEX IF NOT EXISTS idx_record_feedback_record_id ON record_feedback(record_id);
             CREATE INDEX IF NOT EXISTS idx_context_nodes_project_status ON context_nodes(project_id, status);
             CREATE INDEX IF NOT EXISTS idx_context_nodes_scope ON context_nodes(scope_type, scope_id);
             CREATE INDEX IF NOT EXISTS idx_context_nodes_updated_at ON context_nodes(updated_at);
@@ -632,6 +646,17 @@ class ContextStore:
                 )
             if "role_payload" not in columns:
                 conn.execute(f"ALTER TABLE {table_name} ADD COLUMN role_payload TEXT")
+
+    def _ensure_record_confidence_schema(self, conn: sqlite3.Connection) -> None:
+        """Add the earned-confidence column to older records tables.
+
+        This is intentionally records-only: confidence is not versioned and is
+        never written to record_versions.
+        """
+        if "confidence" not in self._table_columns(conn, "records"):
+            conn.execute(
+                "ALTER TABLE records ADD COLUMN confidence REAL NOT NULL DEFAULT 0.5"
+            )
 
     def _column_expr(self, columns: set[str], name: str, default_sql: str) -> str:
         """Return a SELECT expression for an existing column or SQL default."""
@@ -969,6 +994,7 @@ class ContextStore:
                 "source_event_refs",
                 "evidence_refs",
                 "index_text",
+                "confidence",
             },
             "record_versions": {
                 "version_id",
@@ -2078,6 +2104,82 @@ class ContextStore:
             change_kind_override="supersede",
         )
 
+    def record_feedback(
+        self,
+        record_id: str,
+        signal: str,
+        *,
+        note: str | None = None,
+        source_session_id: str | None = None,
+    ) -> dict[str, Any]:
+        """Record one feedback signal and recompute the record's earned confidence.
+
+        This reads the current confidence, appends a row to record_feedback, and
+        updates records.confidence all inside one BEGIN IMMEDIATE transaction, so
+        the read-modify-write cannot race with a concurrent feedback call for the
+        same record_id (mirrors the current-row read in `_update_record_in_conn`).
+        It intentionally does not insert a record_versions row and does not bump
+        the records index generation: confidence is not versioned and is not part
+        of the FTS/embedding index text.
+        """
+        self.initialize()
+        normalized_signal = normalize_feedback_signal(signal)
+        with self.connect() as conn:
+            conn.execute("BEGIN IMMEDIATE")
+            current = conn.execute(
+                "SELECT confidence FROM records WHERE record_id = ?",
+                (record_id,),
+            ).fetchone()
+            if current is None:
+                raise ValueError(f"record_not_found:{record_id}")
+            raw_confidence = _row_value(current, "confidence", None)
+            current_confidence = (
+                float(raw_confidence)
+                if raw_confidence is not None
+                else DEFAULT_RECORD_CONFIDENCE
+            )
+            updated_confidence = next_record_confidence(current_confidence, normalized_signal)
+            conn.execute(
+                """
+                INSERT INTO record_feedback(
+                    feedback_id, record_id, signal, note, source_session_id, created_at
+                )
+                VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    _new_id("fb"),
+                    record_id,
+                    normalized_signal,
+                    _normalize_optional_text(note),
+                    _normalize_optional_text(source_session_id),
+                    _utc_now(),
+                ),
+            )
+            conn.execute(
+                "UPDATE records SET confidence = ? WHERE record_id = ?",
+                (updated_confidence, record_id),
+            )
+        return {
+            "record_id": record_id,
+            "confidence": updated_confidence,
+            "signal": normalized_signal,
+        }
+
+    def list_feedback(self, record_id: str) -> list[dict[str, Any]]:
+        """Return feedback events recorded for one record, oldest first."""
+        self.initialize()
+        with self.connect() as conn:
+            rows = conn.execute(
+                """
+                SELECT feedback_id, record_id, signal, note, source_session_id, created_at
+                FROM record_feedback
+                WHERE record_id = ?
+                ORDER BY created_at ASC, feedback_id ASC
+                """,
+                (record_id,),
+            ).fetchall()
+        return [dict(row) for row in rows]
+
     def search(
         self,
         *,
@@ -2596,6 +2698,12 @@ class ContextStore:
 
     def _record_row_to_dict(self, row: sqlite3.Row) -> dict[str, Any]:
         """Convert one record row into JSON-like data."""
+        raw_confidence = _row_value(row, "confidence", None)
+        confidence = (
+            float(raw_confidence)
+            if raw_confidence is not None
+            else DEFAULT_RECORD_CONFIDENCE
+        )
         return {
             "record_id": str(row["record_id"]),
             "project_id": _row_value(row, "project_id"),
@@ -2625,6 +2733,7 @@ class ContextStore:
             "user_intent": row["user_intent"],
             "what_happened": row["what_happened"],
             "outcomes": row["outcomes"],
+            "confidence": confidence,
         }
 
     def _version_row_to_dict(self, row: sqlite3.Row) -> dict[str, Any]:

--- a/src/lerim/mcp_server.py
+++ b/src/lerim/mcp_server.py
@@ -21,7 +21,7 @@ from lerim.context_brief import (
     resolve_context_brief_project,
     status_to_dict,
 )
-from lerim.server.api import api_answer, api_query, api_status
+from lerim.server.api import api_answer, api_feedback, api_query, api_status
 from lerim.server.daemon import run_context_brief_for_project, run_working_memory_for_project
 from lerim.traces import import_trace_file
 from lerim.traces.submissions import (
@@ -273,6 +273,35 @@ def create_mcp_server() -> FastMCP:
                 limit=max(1, min(int(limit or 20), 100)),
                 offset=max(0, int(offset or 0)),
                 include_total=True,
+            )
+        )
+
+    @mcp.tool(
+        name="lerim_context_feedback",
+        description=(
+            "Record one feedback signal (used, correct, wrong, confirm) against "
+            "an existing Lerim context record and return its updated confidence. "
+            "This is not a memory-save tool: record_id must reference a record "
+            "that already exists."
+        ),
+    )
+    def lerim_context_feedback(
+        record_id: str,
+        signal: str,
+        note: str | None = None,
+        source_session_id: str | None = None,
+    ) -> dict[str, Any]:
+        """Record one feedback signal against an existing context record."""
+        if not str(record_id or "").strip():
+            return {"error": True, "message": "record_id_required"}
+        if not str(signal or "").strip():
+            return {"error": True, "message": "signal_required"}
+        return _run_with_stdout_guard(
+            lambda: api_feedback(
+                record_id,
+                signal,
+                note=note,
+                source_session_id=source_session_id,
             )
         )
 

--- a/src/lerim/redaction.py
+++ b/src/lerim/redaction.py
@@ -1,0 +1,123 @@
+"""Content-based secret and PII redaction applied at the ingestion edge.
+
+This module scrubs common secret and PII patterns out of arbitrary text
+before that text is written to any on-disk cache or compact trace, so raw
+credentials never reach durable records or skills. It uses only the
+standard library ``re`` module -- no new dependencies.
+
+Recognized patterns: private key PEM blocks, passwords embedded in
+connection URLs, Bearer/Authorization header tokens, AWS access and secret
+keys, OpenAI-style API keys (``sk-...``), GitHub tokens
+(``ghp_``/``gho_``/``ghs_``/``ghu_``), and email addresses. Each match is
+replaced with a stable ``[REDACTED:<kind>]`` placeholder. Patterns are kept
+precise (specific prefixes, minimum lengths, required surrounding syntax)
+so ordinary prose and code identifiers are not affected.
+"""
+
+from __future__ import annotations
+
+import re
+
+# ---------------------------------------------------------------------------
+# Individual secret/PII patterns
+# ---------------------------------------------------------------------------
+# Applied in sequence below. Order matters: the private-key block is scrubbed
+# first so its base64 body cannot accidentally feed a narrower pattern later,
+# and the generic email pattern runs last since it is the least specific.
+
+_PRIVATE_KEY_RE = re.compile(
+    r"-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----.*?-----END [A-Z0-9 ]*PRIVATE KEY-----",
+    re.DOTALL,
+)
+# A truncated/unterminated key block (BEGIN present, no matching END anywhere
+# in the text -- e.g. a partial tool-output capture) is not matched by
+# _PRIVATE_KEY_RE above. Applied second, after paired blocks are already
+# replaced, this catches any BEGIN marker left over and redacts through the
+# end of the text so a truncated capture cannot leak its base64 body.
+_PRIVATE_KEY_UNTERMINATED_RE = re.compile(
+    r"-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----.*",
+    re.DOTALL,
+)
+
+_URL_PASSWORD_RE = re.compile(
+    r"([A-Za-z][A-Za-z0-9+.\-]*://[^\s:/@]+):([^\s@/]+)@"
+)
+
+# A digit is required in the token itself so ordinary words after "Bearer"
+# (e.g. "the bearer of good news") or after an "Authorization:" label in
+# prose do not get treated as secrets.
+_BEARER_RE = re.compile(r"(?i)\bBearer\s+(?=[A-Za-z0-9._-]*\d)[A-Za-z0-9._-]{8,}")
+_AUTH_HEADER_RE = re.compile(
+    r"(?i)\bAuthorization\s*:\s*(?=[A-Za-z0-9._-]*\d)[A-Za-z0-9._-]{8,}"
+)
+
+_AWS_SECRET_RE = re.compile(
+    r"(?i)\b(aws[_-]secret(?:[_-]access)?[_-]key)(\s*[:=]\s*)"
+    r"[\"']?([A-Za-z0-9/+=]{40})[\"']?"
+)
+_AWS_ACCESS_KEY_RE = re.compile(r"\bAKIA[0-9A-Z]{16}\b")
+
+_OPENAI_KEY_RE = re.compile(r"\bsk-[A-Za-z0-9_-]{16,}\b")
+
+_GITHUB_TOKEN_RE = re.compile(r"\bgh[opsu]_[A-Za-z0-9]{20,}\b")
+
+# The TLD position excludes common image/media file extensions so that
+# retina-scale asset filenames (icon@2x.png, logo@3x.jpg, ...) and similar
+# "name@token.ext" filename shapes are not mistaken for email addresses.
+# None of these extensions are real TLDs, so genuine email addresses are
+# never affected by this exclusion.
+_EMAIL_RE = re.compile(
+    r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\."
+    r"(?!(?i:png|jpe?g|gif|svg|webp|ico|bmp|tiff?|avif|heic|heif)\b)"
+    r"[A-Za-z]{2,}\b"
+)
+
+
+def _replace_url_password(match: re.Match[str]) -> str:
+    """Return a scheme://user: prefix with the URL's embedded password redacted."""
+    prefix = match.group(1)
+    return f"{prefix}:[REDACTED:password]@"
+
+
+def _replace_aws_secret(match: re.Match[str]) -> str:
+    """Return an AWS secret-key assignment with its value redacted."""
+    key_name, separator = match.group(1), match.group(2)
+    return f"{key_name}{separator}[REDACTED:aws_secret_key]"
+
+
+def redact_text(text: str) -> str:
+    """Scrub common secrets and PII from ``text``, returning the redacted copy.
+
+    Each recognized secret is replaced with a stable ``[REDACTED:<kind>]``
+    placeholder (for example ``[REDACTED:api_key]`` or ``[REDACTED:email]``).
+    Text containing none of the recognized patterns is returned unchanged.
+    """
+    redacted = _PRIVATE_KEY_RE.sub("[REDACTED:private_key]", text)
+    redacted = _PRIVATE_KEY_UNTERMINATED_RE.sub("[REDACTED:private_key]", redacted)
+    redacted = _URL_PASSWORD_RE.sub(_replace_url_password, redacted)
+    redacted = _BEARER_RE.sub("Bearer [REDACTED:token]", redacted)
+    redacted = _AUTH_HEADER_RE.sub("Authorization: [REDACTED:token]", redacted)
+    redacted = _AWS_SECRET_RE.sub(_replace_aws_secret, redacted)
+    redacted = _AWS_ACCESS_KEY_RE.sub("[REDACTED:aws_access_key]", redacted)
+    redacted = _OPENAI_KEY_RE.sub("[REDACTED:api_key]", redacted)
+    redacted = _GITHUB_TOKEN_RE.sub("[REDACTED:github_token]", redacted)
+    redacted = _EMAIL_RE.sub("[REDACTED:email]", redacted)
+    return redacted
+
+
+if __name__ == "__main__":
+    """Run a real-path smoke test for redact_text."""
+    sample = (
+        "Contact person@example.com about the sk-abcdefghijklmnopqrstuvwxyz "
+        "key and the AKIAABCDEFGHIJKLMNOP access key."
+    )
+    result = redact_text(sample)
+    assert "person@example.com" not in result
+    assert "sk-abcdefghijklmnopqrstuvwxyz" not in result
+    assert "AKIAABCDEFGHIJKLMNOP" not in result
+    assert "[REDACTED:email]" in result
+    assert "[REDACTED:api_key]" in result
+    assert "[REDACTED:aws_access_key]" in result
+
+    plain = "an ordinary sentence with no secrets at all"
+    assert redact_text(plain) == plain

--- a/src/lerim/server/api.py
+++ b/src/lerim/server/api.py
@@ -594,6 +594,92 @@ def api_query(
     }
 
 
+def api_feedback(
+    record_id: str,
+    signal: str,
+    *,
+    note: str | None = None,
+    source_session_id: str | None = None,
+    scope: str = "all",
+    project: str | None = None,
+) -> dict[str, Any]:
+    """Record one feedback signal against an existing context record.
+
+    NOTE: `scope`/`project` are resolved (mirroring `api_query`) only to
+    validate the `project` token and to populate `projects_used`/`scope` in
+    the response. `record_id` is a global identifier and `store.record_feedback`
+    takes no project filter, so this resolution is NOT enforced access control
+    -- any caller can submit feedback for any record_id regardless of scope.
+    See docs/contracts/feedback-and-confidence.md for the full disclosure and
+    the pending product decision on whether to enforce project scope here.
+    """
+    config = get_config()
+    normalized_scope = (
+        "project" if project or str(scope).strip().lower() == "project" else "all"
+    )
+    try:
+        selected_projects = _resolve_selected_projects(
+            config=config,
+            scope=normalized_scope,
+            project=project,
+        )
+    except ValueError as exc:
+        return {
+            "error": True,
+            "message": str(exc),
+            "projects_used": [],
+        }
+
+    store = _context_store(config)
+    try:
+        result = store.record_feedback(
+            record_id,
+            signal,
+            note=note,
+            source_session_id=source_session_id,
+        )
+    except ValueError as exc:
+        return {
+            "error": True,
+            "message": str(exc),
+            "projects_used": [name for name, _ in selected_projects],
+            "status_code": 400,
+        }
+    except sqlite3.Error:
+        return {
+            "error": True,
+            "message": "Context query storage is unavailable.",
+            "projects_used": [name for name, _ in selected_projects],
+            "status_code": 503,
+        }
+    return {
+        **result,
+        "error": False,
+        "projects_used": [name for name, _ in selected_projects],
+        "scope": normalized_scope,
+    }
+
+
+def api_feedback_list(record_id: str) -> dict[str, Any]:
+    """Return recorded feedback events for one context record."""
+    config = get_config()
+    store = _context_store(config)
+    try:
+        rows = store.list_feedback(record_id)
+    except sqlite3.Error:
+        return {
+            "error": True,
+            "message": "Context query storage is unavailable.",
+            "status_code": 503,
+        }
+    return {
+        "record_id": record_id,
+        "rows": rows,
+        "count": len(rows),
+        "error": False,
+    }
+
+
 def api_record_filters(
     project: str | None = None,
     status: str | None = None,

--- a/src/lerim/server/cli.py
+++ b/src/lerim/server/cli.py
@@ -41,6 +41,7 @@ from lerim.integrations.mcp_connect import (
 )
 
 from lerim.server.api import (
+    api_feedback,
     api_memory_reset,
     api_project_add,
     api_project_list,
@@ -89,6 +90,7 @@ from lerim.config.settings import (
 from lerim.config.tracing import configure_tracing
 from lerim.context import ContextStore
 from lerim.context.query_spec import QUERY_ENTITIES, QUERY_MODES, QUERY_ORDER_FIELDS
+from lerim.context.spec import ALLOWED_FEEDBACK_SIGNALS
 from lerim.profiles import (
     bundled_signal_pack_ids,
     get_signal_pack,
@@ -1559,6 +1561,23 @@ def _cmd_query(args: argparse.Namespace) -> int:
         return 1 if payload.get("error") else 0
     if payload.get("error"):
         _emit(str(payload.get("message") or "query failed"), file=sys.stderr)
+        return 1
+    _emit(json.dumps(payload, indent=2, ensure_ascii=True))
+    return 0
+
+
+def _cmd_feedback(args: argparse.Namespace) -> int:
+    """Record one feedback signal against a context record and print the result."""
+    payload = api_feedback(
+        args.record_id,
+        args.signal,
+        note=getattr(args, "note", None),
+    )
+    if args.json:
+        _emit(json.dumps(payload, indent=2, ensure_ascii=True))
+        return 1 if payload.get("error") else 0
+    if payload.get("error"):
+        _emit(str(payload.get("message") or "feedback failed"), file=sys.stderr)
         return 1
     _emit(json.dumps(payload, indent=2, ensure_ascii=True))
     return 0
@@ -3475,6 +3494,31 @@ def build_parser() -> argparse.ArgumentParser:
     query.add_argument("--offset", type=int, default=0)
     query.add_argument("--include-total", action="store_true")
     query.set_defaults(func=_cmd_query)
+
+    # ── feedback ─────────────────────────────────────────────────────
+    feedback = sub.add_parser(
+        "feedback",
+        formatter_class=_F,
+        help="Record a feedback signal against a context record",
+        description=(
+            "Record one feedback signal against an existing context record and "
+            "print its updated earned confidence.\n\n"
+            "Example: lerim feedback rec_abc123 correct --note 'Confirmed in prod'"
+        ),
+    )
+    feedback.add_argument("record_id", help="Existing context record id.")
+    feedback.add_argument(
+        "signal",
+        choices=ALLOWED_FEEDBACK_SIGNALS,
+        help="Feedback signal to record.",
+    )
+    feedback.add_argument("--note", help="Optional free-text note for this feedback event.")
+    feedback.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit machine-readable JSON output.",
+    )
+    feedback.set_defaults(func=_cmd_feedback)
 
     # ── context ────────────────────────────────────────────────────────
     context = sub.add_parser(

--- a/src/lerim/server/httpd.py
+++ b/src/lerim/server/httpd.py
@@ -35,6 +35,8 @@ from lerim.server.api import (
     api_connect,
     api_connect_list,
     api_curate,
+    api_feedback,
+    api_feedback_list,
     api_health,
     api_ingest,
     api_project_add,
@@ -1201,6 +1203,16 @@ WHERE 1=1{where_sql} ORDER BY d.agent_type ASC""",
             return
         self._json(record)
 
+    def _api_record_feedback_list(self, path: str) -> None:
+        """Return recorded feedback events for one context record."""
+        record_id = unquote(path[len("/api/records/") : -len("/feedback")]).strip("/")
+        if not record_id:
+            self._error(HTTPStatus.BAD_REQUEST, "Missing record id")
+            return
+        payload = api_feedback_list(record_id)
+        status = int(payload.pop("status_code", HTTPStatus.OK))
+        self._json(payload, status=status)
+
     def _api_refine_status(self) -> None:
         """Return queue and recent run status for refine panel."""
         try:
@@ -1959,6 +1971,9 @@ WHERE 1=1{where_sql} ORDER BY d.agent_type ASC""",
         if path == "/api/logs":
             self._api_logs(query)
             return
+        if path.startswith("/api/records/") and path.endswith("/feedback"):
+            self._api_record_feedback_list(path)
+            return
         if path.startswith("/api/records/"):
             try:
                 self._api_record_detail(path, query)
@@ -2188,6 +2203,30 @@ WHERE 1=1{where_sql} ORDER BY d.agent_type ASC""",
             if result.get("error"):
                 status = int(result.get("status_code") or HTTPStatus.BAD_REQUEST)
                 self._error(HTTPStatus(status), str(result.get("message") or "query failed"))
+                return
+            self._json(result)
+            return
+        if path.startswith("/api/records/") and path.endswith("/feedback"):
+            record_id = unquote(path[len("/api/records/") : -len("/feedback")]).strip("/")
+            if not record_id:
+                self._error(HTTPStatus.BAD_REQUEST, "Missing record id")
+                return
+            body = read_body()
+            if body is None:
+                return
+            signal = str(body.get("signal") or "").strip()
+            if not signal:
+                self._error(HTTPStatus.BAD_REQUEST, "Missing 'signal'")
+                return
+            result = api_feedback(
+                record_id,
+                signal,
+                note=str(body.get("note") or "").strip() or None,
+                source_session_id=str(body.get("source_session_id") or "").strip() or None,
+            )
+            if result.get("error"):
+                status = int(result.get("status_code") or HTTPStatus.BAD_REQUEST)
+                self._error(HTTPStatus(status), str(result.get("message") or "feedback failed"))
                 return
             self._json(result)
             return

--- a/src/lerim/skill_stewardship/artifacts.py
+++ b/src/lerim/skill_stewardship/artifacts.py
@@ -224,10 +224,22 @@ def _belongs_to_artifact(root: Path, path: Path) -> bool:
 
 
 def _file_role(*, root: Path, entry: Path, path: Path) -> str:
-    """Classify one artifact file's role."""
-    if path.resolve() == entry.resolve():
+    """Classify one artifact file's role.
+
+    A co-located AGENTS.md is treated as entry-caliber alongside a SKILL.md entry
+    (both get the "entry" role) instead of being demoted to a plain reference file.
+    """
+    resolved = path.resolve()
+    entry_resolved = entry.resolve()
+    if resolved == entry_resolved:
         return "entry"
-    rel = path.resolve().relative_to(root.resolve()) if root.is_dir() else Path(path.name)
+    if (
+        resolved.name == "AGENTS.md"
+        and entry_resolved.name == "SKILL.md"
+        and resolved.parent == entry_resolved.parent
+    ):
+        return "entry"
+    rel = resolved.relative_to(root.resolve()) if root.is_dir() else Path(path.name)
     if rel.parts and rel.parts[0] in {"scripts"}:
         return "script"
     if rel.parts and rel.parts[0] in {"assets"}:

--- a/src/lerim/skill_stewardship/pipeline.py
+++ b/src/lerim/skill_stewardship/pipeline.py
@@ -24,7 +24,12 @@ from lerim.skill_stewardship.schemas import (
     ArtifactManifest,
 )
 from lerim.skill_stewardship.signatures import CompileSkillUpdateProposal
-from lerim.skill_stewardship.validation import frontmatter_block, path_belongs_to_manifest, validate_proposal
+from lerim.skill_stewardship.validation import (
+    frontmatter_block,
+    patch_evidence_errors,
+    path_belongs_to_manifest,
+    validate_proposal,
+)
 
 DEFAULT_RECORD_LIMIT = 80
 PREFERRED_RECORD_ROLES = [
@@ -84,8 +89,18 @@ class SkillStewardshipPipeline(dspy.Module):
             )
             draft = self._compile(target=refreshed, base=base, manifest=manifest, files=files, records=records)
             draft = hydrate_patch_text(base=base, draft=draft)
-            guard = guard_proposal(draft=draft, policy=refreshed.auto_apply_policy, manifest=manifest)
-            validation = validate_proposal(base_path=base, manifest=manifest, proposal=draft)
+            guard = guard_proposal(
+                draft=draft,
+                policy=refreshed.auto_apply_policy,
+                manifest=manifest,
+                store=self.repository.context_store,
+            )
+            validation = validate_proposal(
+                base_path=base,
+                manifest=manifest,
+                proposal=draft,
+                store=self.repository.context_store,
+            )
             signals = self.repository.save_signals(run_id=run_id, target_id=refreshed.target_id, draft=draft)
             if draft.patches and guard.accepted:
                 status = "pending_review" if validation.ok else "failed_validation"
@@ -192,9 +207,18 @@ def guard_proposal(
     draft: SkillProposalDraft,
     policy: AutoApplyPolicy,
     manifest: ArtifactManifest | None = None,
+    store: ContextStore | None = None,
 ) -> ProposalGuardResult:
-    """Apply deterministic safety gates to a model-authored proposal."""
+    """Apply deterministic safety gates to a model-authored proposal.
+
+    ``store`` is optional and backward compatible: when omitted, the evidence gate
+    only checks that each patch cites at least one record id (presence only), same
+    as before. When provided, cited record ids must exist and the patch's new text
+    must be evidence-supported (see ``validation.patch_evidence_errors``); any such
+    problem keeps the proposal out of ``accepted`` the same way missing evidence does.
+    """
     reasons: list[str] = []
+    evidence_reasons: list[str] = []
     if not draft.patches:
         return ProposalGuardResult(accepted=False, risk_level="low", auto_apply_eligible=False, reasons=["no_patch"])
     risk = _highest_risk([draft.risk_level, *(patch.risk for patch in draft.patches)])
@@ -215,8 +239,13 @@ def guard_proposal(
     if removed_lines > policy.max_removed_lines:
         reasons.append(f"removed lines exceed auto-apply max_removed_lines={policy.max_removed_lines}")
     for patch in draft.patches:
+        patch_evidence_reasons: list[str] = []
         if not patch.evidence_record_ids:
-            reasons.append(f"{patch.relative_path}: missing evidence")
+            patch_evidence_reasons.append(f"{patch.relative_path}: missing evidence")
+        elif store is not None:
+            patch_evidence_reasons.extend(patch_evidence_errors(store=store, patch=patch))
+        evidence_reasons.extend(patch_evidence_reasons)
+        reasons.extend(patch_evidence_reasons)
         reasons.extend(_patch_policy_reasons(patch=patch, policy=policy, manifest=manifest))
     auto_apply = (
         policy.enabled
@@ -227,7 +256,7 @@ def guard_proposal(
         and not reasons
     )
     return ProposalGuardResult(
-        accepted=all("missing evidence" not in reason for reason in reasons),
+        accepted=not evidence_reasons,
         risk_level=risk,
         auto_apply_eligible=auto_apply,
         reasons=reasons,

--- a/src/lerim/skill_stewardship/validation.py
+++ b/src/lerim/skill_stewardship/validation.py
@@ -2,11 +2,26 @@
 
 from __future__ import annotations
 
+import re
+from difflib import SequenceMatcher
 from pathlib import Path
 
 import yaml
 
-from lerim.skill_stewardship.schemas import ArtifactManifest, SkillProposalDraft, ValidationResult
+from lerim.context import ContextStore
+from lerim.skill_stewardship.schemas import ArtifactManifest, SkillPatch, SkillProposalDraft, ValidationResult
+
+_MEANINGFUL_TOKEN = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+_STOPWORDS = {
+    "this", "that", "with", "from", "have", "will", "your", "their",
+    "these", "those", "into", "when", "than", "then", "also", "such",
+    "each", "more", "most", "some", "only", "just", "must", "should",
+    "would", "could", "about", "which", "while", "where", "there",
+    "been", "being", "does", "done", "make", "made", "used", "using",
+    "text", "file", "files",
+}
+_QUOTE_PHRASE_SIZE = 4
+_SUPPORT_OVERLAP_THRESHOLD = 0.25
 
 
 def validate_proposal(
@@ -14,8 +29,14 @@ def validate_proposal(
     base_path: Path,
     manifest: ArtifactManifest,
     proposal: SkillProposalDraft,
+    store: ContextStore | None = None,
 ) -> ValidationResult:
-    """Validate proposal shape, paths, frontmatter, and artifact constraints."""
+    """Validate proposal shape, paths, frontmatter, artifact, and evidence constraints.
+
+    ``store`` is optional and backward compatible: when omitted, validation behaves
+    exactly as before. When provided, each patch's cited evidence records must exist
+    and the patch's newly introduced text must show meaningful support from them.
+    """
     checks: list[str] = []
     errors: list[str] = []
     base = base_path.resolve()
@@ -42,6 +63,8 @@ def validate_proposal(
                 errors.append(f"{patch.relative_path}: new file is not allowed for {manifest.target_type}")
         if not patch.evidence_record_ids:
             errors.append(f"{patch.relative_path}: missing evidence_record_ids")
+        elif store is not None:
+            errors.extend(patch_evidence_errors(store=store, patch=patch))
         if patch.relative_path == manifest.entry_file:
             if frontmatter_block(str(patch.before_text or "")) and not frontmatter_block(patch.after_text):
                 errors.append(f"{manifest.entry_file}: must preserve existing YAML frontmatter")
@@ -52,7 +75,105 @@ def validate_proposal(
         checks.append("bounded_changed_files")
     else:
         errors.append("proposal changes too many files for one review")
+    if store is not None:
+        checks.append("evidence_checked")
     return ValidationResult(ok=not errors, checks=checks, errors=errors)
+
+
+def patch_evidence_errors(*, store: ContextStore, patch: SkillPatch) -> list[str]:
+    """Return evidence problems for one patch: missing records or unsupported text.
+
+    Each cited record id is looked up with ``store.fetch_record``. A missing record
+    is reported directly. When at least one cited record exists, the patch's newly
+    introduced text (the diff for a modify patch, the whole file for a create patch)
+    must share a meaningful token or quoted phrase with the cited records' combined
+    text; otherwise the patch is reported as unsupported. Callers that also want a
+    bare "no evidence cited" error should check ``patch.evidence_record_ids`` first,
+    since this function assumes there is at least one id to look up.
+    """
+    problems: list[str] = []
+    evidence_texts: list[str] = []
+    for record_id in patch.evidence_record_ids:
+        record = store.fetch_record(record_id)
+        if record is None:
+            problems.append(f"{patch.relative_path}: evidence record not found: {record_id}")
+            continue
+        evidence_texts.append(_record_text(record))
+    if not evidence_texts:
+        return problems
+    new_text = _patch_new_text(patch)
+    if not _text_supported_by_evidence(new_text, "\n".join(evidence_texts)):
+        problems.append(f"{patch.relative_path}: after_text is not supported by cited evidence records")
+    return problems
+
+
+def _record_text(record: dict[str, object]) -> str:
+    """Flatten one fetched record's narrative fields into a single text blob."""
+    fields = (
+        "title",
+        "body",
+        "decision",
+        "why",
+        "alternatives",
+        "consequences",
+        "user_intent",
+        "what_happened",
+        "outcomes",
+    )
+    return "\n".join(str(record.get(field) or "") for field in fields)
+
+
+def _patch_new_text(patch: SkillPatch) -> str:
+    """Return the text a patch newly introduces, for evidence-support checks."""
+    before = patch.before_text or ""
+    if patch.change_type == "create" or not before.strip():
+        return patch.after_text
+    return _added_lines(before, patch.after_text)
+
+
+def _added_lines(before: str, after: str) -> str:
+    """Return only the lines a modify patch adds or changes, via a line-level diff."""
+    before_lines = before.splitlines()
+    after_lines = after.splitlines()
+    matcher = SequenceMatcher(a=before_lines, b=after_lines, autojunk=False)
+    added = [
+        after_lines[index]
+        for tag, _i1, _i2, j1, j2 in matcher.get_opcodes()
+        if tag in {"insert", "replace"}
+        for index in range(j1, j2)
+    ]
+    return "\n".join(added)
+
+
+def _text_supported_by_evidence(text: str, evidence_text: str) -> bool:
+    """Return whether text shares a meaningful quote or enough tokens with evidence_text."""
+    candidate_tokens = _meaningful_tokens(text)
+    if not candidate_tokens:
+        return True
+    evidence_tokens = _meaningful_tokens(evidence_text)
+    if not evidence_tokens:
+        return False
+    if _quote_phrases(text) & _quote_phrases(evidence_text):
+        return True
+    overlap = candidate_tokens & evidence_tokens
+    return len(overlap) / len(candidate_tokens) >= _SUPPORT_OVERLAP_THRESHOLD
+
+
+def _meaningful_tokens(text: str) -> set[str]:
+    """Return lowercase content words of length 4+, with common stopwords removed."""
+    tokens = {match.group(0).lower() for match in _MEANINGFUL_TOKEN.finditer(text)}
+    return {token for token in tokens if len(token) >= 4 and token not in _STOPWORDS}
+
+
+def _quote_phrases(text: str) -> set[str]:
+    """Return normalized 4-word phrases from text for verbatim quote-overlap checks."""
+    words = [match.group(0).lower() for match in _MEANINGFUL_TOKEN.finditer(text)]
+    if len(words) < _QUOTE_PHRASE_SIZE:
+        return set()
+    return {
+        " ".join(words[index : index + _QUOTE_PHRASE_SIZE])
+        for index in range(len(words) - _QUOTE_PHRASE_SIZE + 1)
+    }
 
 
 def frontmatter_block(text: str) -> str | None:

--- a/src/lerim/skills/cli-reference.md
+++ b/src/lerim/skills/cli-reference.md
@@ -52,6 +52,7 @@ generation for the resolved project and record service runs.
 - `dashboard`
 - `answer`
 - `query`
+- `feedback`
 - `context` (`records`)
 - `profile` (`list`, `show`, `validate`, `register`) (host-only)
 - `status`
@@ -215,6 +216,7 @@ Exposed tools:
 - `lerim_context_answer`
 - `lerim_context_search`
 - `lerim_records_list`
+- `lerim_context_feedback`
 - `lerim_trace_submit`
 - `lerim_ingest_status`
 
@@ -529,6 +531,30 @@ lerim query sessions list --order-by created_at --limit 20
 | `--limit` | `20` | Page size for `list` |
 | `--offset` | `0` | Page offset for `list` |
 | `--include-total` | `false` | Include total matching rows for `list` |
+
+### `lerim feedback`
+
+Record one feedback signal against an existing context record and print its
+updated earned confidence. Feedback references an existing `record_id` only; it
+never creates a memory. Confidence is updated in place (not versioned) and
+factors into retrieval ranking so confirmed records rise and wrong ones fade.
+
+```bash
+lerim feedback rec_abc123 correct
+lerim feedback rec_abc123 wrong --note "Superseded by the new caching decision"
+lerim feedback rec_abc123 used --json
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `record_id` | required | Existing context record id |
+| `signal` | required | `used`, `correct`, `wrong`, or `confirm` |
+| `--note` | -- | Optional free-text note for this feedback event |
+| `--json` | off | Print the raw JSON result (record id, signal, new confidence) |
+
+Signal deltas (applied to the current confidence, clamped to `[0, 1]`):
+`correct` / `confirm` `+0.15`, `used` `+0.05`, `wrong` `-0.25`. New records start
+at `0.5`.
 
 ### `lerim profile`
 

--- a/src/lerim/traces/envelope.py
+++ b/src/lerim/traces/envelope.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any
 
 from lerim.adapters.common import make_canonical_entry, normalize_timestamp_iso
+from lerim.redaction import redact_text
 
 _EVENT_LIST_FIELDS = ("events", "messages", "trace", "steps", "items")
 _CONTENT_FIELDS = ("content", "text", "message", "summary", "observation")
@@ -80,10 +81,11 @@ def load_generic_trace(path: Path) -> NormalizedTrace:
 
 
 def write_compact_trace(trace: NormalizedTrace, destination: Path) -> Path:
-    """Write canonical compact events to destination JSONL."""
+    """Write canonical compact events to destination JSONL, with secrets redacted."""
     destination.parent.mkdir(parents=True, exist_ok=True)
     lines = [json.dumps(event, ensure_ascii=False) for event in trace.events]
-    destination.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    text = redact_text("\n".join(lines) + "\n")
+    destination.write_text(text, encoding="utf-8")
     return destination
 
 

--- a/tests/live_helpers.py
+++ b/tests/live_helpers.py
@@ -45,13 +45,22 @@ FRAMEWORK_TOOL_NAMES = {
 }
 TRACE_INGESTION_EVENT_NAMES = frozenset(
     {
+        # Keep in sync with the stage labels emitted by
+        # agents/trace_ingestion/pipeline.py (call_model_step stage=...).
         "resolve_scope",
         "read_window",
         "scan_window",
         "filter_signals",
         "synthesize_records",
+        "guard_records",
+        "polish_records",
+        "annotate_record_roles",
         "save_context",
         "model_retry",
+        # coding-source-profile sub-stages
+        "extract_coding_project_identity",
+        "extract_coding_user_strategy",
+        "select_coding_durable_records",
     }
 )
 CONTEXT_CURATOR_EVENT_NAMES = frozenset(

--- a/tests/live_helpers.py
+++ b/tests/live_helpers.py
@@ -20,6 +20,7 @@ REQUIRED_CONTEXT_TABLES = {
     "projects",
     "records",
     "record_embeddings",
+    "record_feedback",
     "record_versions",
     "records_fts",
     "schema_meta",

--- a/tests/unit/adapters/test_common_redaction.py
+++ b/tests/unit/adapters/test_common_redaction.py
@@ -1,0 +1,73 @@
+"""Unit tests for redaction wiring in lerim.adapters.common.write_session_cache.
+
+write_session_cache funnels every built-in adapter's compacted session
+output through redact_text before the cache file is written, so these
+tests exercise that specific wiring rather than the redaction patterns
+themselves (covered in tests/unit/test_redaction.py).
+"""
+
+from __future__ import annotations
+
+from lerim.adapters.common import write_session_cache
+
+
+def test_write_session_cache_redacts_secret_in_compacted_output(tmp_path):
+    """A secret present in the compacted text is redacted before writing."""
+    cache_dir = tmp_path / "cache"
+    lines = ['{"message":"my key is sk-abcdefghijklmnopqrstuvwx1234"}']
+
+    def identity_compact(raw: str) -> str:
+        """Identity compactor -- returns input unchanged."""
+        return raw
+
+    result_path = write_session_cache(cache_dir, "run-secret", lines, identity_compact)
+
+    content = result_path.read_text(encoding="utf-8")
+    assert "sk-abcdefghijklmnopqrstuvwx1234" not in content
+    assert "[REDACTED:api_key]" in content
+
+
+def test_write_session_cache_redacts_email_produced_by_compact_fn(tmp_path):
+    """Redaction runs on compact_fn's output, not just the raw input lines."""
+    cache_dir = tmp_path / "cache"
+
+    def append_email(raw: str) -> str:
+        """Compactor that appends an email address, simulating adapter output."""
+        return raw.strip() + " contact ops@example.com\n"
+
+    write_session_cache(cache_dir, "run-email", ["hello"], append_email)
+    content = (cache_dir / "run-email.jsonl").read_text(encoding="utf-8")
+
+    assert "ops@example.com" not in content
+    assert "[REDACTED:email]" in content
+
+
+def test_write_session_cache_redacts_bearer_token(tmp_path):
+    """A bearer token embedded in session lines is redacted before writing."""
+    cache_dir = tmp_path / "cache"
+    lines = ['{"header":"Authorization: Bearer abcdef1234567890token"}']
+
+    write_session_cache(cache_dir, "run-bearer", lines, lambda raw: raw)
+    content = (cache_dir / "run-bearer.jsonl").read_text(encoding="utf-8")
+
+    assert "abcdef1234567890token" not in content
+    assert "[REDACTED:token]" in content
+
+
+def test_write_session_cache_preserves_normal_text(tmp_path):
+    """Ordinary session content with no secrets passes through unchanged."""
+    cache_dir = tmp_path / "cache"
+    lines = ['{"message":"just a normal note about the sprint plan"}']
+
+    write_session_cache(cache_dir, "run-normal", lines, lambda raw: raw)
+    content = (cache_dir / "run-normal.jsonl").read_text(encoding="utf-8")
+
+    assert content == '{"message":"just a normal note about the sprint plan"}\n'
+
+
+def test_write_session_cache_still_returns_correct_path(tmp_path):
+    """Wiring in redaction does not change write_session_cache's return value."""
+    cache_dir = tmp_path / "cache"
+    result_path = write_session_cache(cache_dir, "run-path", ["line"], lambda raw: raw)
+    assert result_path == cache_dir / "run-path.jsonl"
+    assert result_path.exists()

--- a/tests/unit/context/test_retrieval.py
+++ b/tests/unit/context/test_retrieval.py
@@ -1,0 +1,613 @@
+"""Unit tests for confidence + recency reranking and the relevance floor.
+
+Covers the new pure-function ranking helpers in lerim.context.retrieval:
+RRF_K's conventional value, the confidence and recency multipliers,
+blend_confidence_and_recency, apply_relevance_floor, and SearchHit.confidence.
+
+rrf_fuse's own rank-fusion formula (unaffected here beyond RRF_K's new value)
+is already covered by tests/unit/context/test_store_search.py. Broad
+end-to-end ranking validation is the lead's job, but
+TestSearchRecordsThroughLiveStore pins the one behavior specific to this
+lane's search_records restructuring: candidate metadata must be fetched and
+reranked for the FULL fused set before the `limit` slice, not after.
+"""
+
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+import lerim.context.retrieval as retrieval
+from lerim.context.project_identity import resolve_project_identity
+from lerim.context.retrieval import (
+    CONFIDENCE_MULTIPLIER_CEILING,
+    CONFIDENCE_MULTIPLIER_FLOOR,
+    DEFAULT_LEXICAL_RRF_WEIGHT,
+    DEFAULT_SEMANTIC_RRF_WEIGHT,
+    RECENCY_BOOST_WEIGHT,
+    RELEVANCE_FLOOR,
+    RELEVANCE_FLOOR_REFERENCE_RANK,
+    RRF_K,
+    SearchHit,
+    apply_relevance_floor,
+    blend_confidence_and_recency,
+    rrf_fuse,
+)
+from lerim.context.spec import DEFAULT_RECORD_CONFIDENCE
+from lerim.context.store import ContextStore
+
+
+def _base_hit_kwargs() -> dict:
+    """Return a fresh kwargs dict for constructing a minimal SearchHit."""
+    return dict(
+        record_id="rec_1",
+        project_id="proj_1",
+        kind="fact",
+        title="t",
+        body="b",
+        status="active",
+        created_at="2026-01-01T00:00:00+00:00",
+        updated_at="2026-01-01T00:00:00+00:00",
+        valid_from="2026-01-01T00:00:00+00:00",
+        valid_until=None,
+        score=0.5,
+        sources=[],
+    )
+
+
+class TestRRFConstants:
+    """RRF_K must use a conventional damping value, not the old over-eager one."""
+
+    def test_rrf_k_is_conventional_60(self):
+        assert RRF_K == 60
+
+    def test_rrf_k_is_not_the_old_over_weighting_value(self):
+        assert RRF_K != 2
+
+    def test_default_weights_are_unchanged(self):
+        assert DEFAULT_SEMANTIC_RRF_WEIGHT == 0.7
+        assert DEFAULT_LEXICAL_RRF_WEIGHT == 0.3
+
+
+class TestConfidenceMultiplier:
+    """Tests for the private _confidence_multiplier helper."""
+
+    def test_default_confidence_is_neutral(self):
+        assert retrieval._confidence_multiplier(0.5) == pytest.approx(1.0)
+
+    def test_zero_confidence_hits_the_floor(self):
+        assert retrieval._confidence_multiplier(0.0) == pytest.approx(CONFIDENCE_MULTIPLIER_FLOOR)
+
+    def test_full_confidence_hits_the_ceiling(self):
+        assert retrieval._confidence_multiplier(1.0) == pytest.approx(CONFIDENCE_MULTIPLIER_CEILING)
+
+    def test_monotonically_increasing_with_confidence(self):
+        low = retrieval._confidence_multiplier(0.2)
+        mid = retrieval._confidence_multiplier(0.5)
+        high = retrieval._confidence_multiplier(0.8)
+        assert low < mid < high
+
+    def test_out_of_range_high_clamps_to_ceiling(self):
+        assert retrieval._confidence_multiplier(5.0) == pytest.approx(CONFIDENCE_MULTIPLIER_CEILING)
+
+    def test_out_of_range_low_clamps_to_floor(self):
+        assert retrieval._confidence_multiplier(-5.0) == pytest.approx(CONFIDENCE_MULTIPLIER_FLOOR)
+
+
+class TestRecencyMultipliers:
+    """Tests for the private _recency_multipliers helper."""
+
+    def test_single_candidate_is_neutral(self):
+        result = retrieval._recency_multipliers({"r1": "2026-01-01T00:00:00+00:00"})
+        assert result == {"r1": pytest.approx(1.0)}
+
+    def test_empty_input_returns_empty(self):
+        assert retrieval._recency_multipliers({}) == {}
+
+    def test_newest_gets_full_positive_boost_oldest_full_penalty(self):
+        result = retrieval._recency_multipliers(
+            {
+                "old": "2020-01-01T00:00:00+00:00",
+                "new": "2026-01-01T00:00:00+00:00",
+            }
+        )
+        assert result["new"] == pytest.approx(1.0 + RECENCY_BOOST_WEIGHT)
+        assert result["old"] == pytest.approx(1.0 - RECENCY_BOOST_WEIGHT)
+
+    def test_middle_candidate_lands_at_neutral(self):
+        result = retrieval._recency_multipliers(
+            {
+                "old": "2026-01-01T00:00:00+00:00",
+                "mid": "2026-01-02T00:00:00+00:00",
+                "new": "2026-01-03T00:00:00+00:00",
+            }
+        )
+        assert result["old"] < result["mid"] < result["new"]
+        assert result["mid"] == pytest.approx(1.0)
+
+    def test_identical_timestamps_are_all_neutral(self):
+        result = retrieval._recency_multipliers(
+            {
+                "a": "2026-01-01T00:00:00+00:00",
+                "b": "2026-01-01T00:00:00+00:00",
+            }
+        )
+        assert result == {"a": pytest.approx(1.0), "b": pytest.approx(1.0)}
+
+    def test_unparseable_timestamp_is_neutral_but_does_not_block_others(self):
+        result = retrieval._recency_multipliers(
+            {
+                "old": "2020-01-01T00:00:00+00:00",
+                "new": "2026-01-01T00:00:00+00:00",
+                "bad": "not-a-timestamp",
+            }
+        )
+        assert result["bad"] == pytest.approx(1.0)
+        assert result["new"] > result["old"]
+
+    def test_none_timestamp_is_neutral(self):
+        assert retrieval._recency_multipliers({"r1": None}) == {"r1": pytest.approx(1.0)}
+
+    def test_boost_never_exceeds_configured_weight(self):
+        result = retrieval._recency_multipliers(
+            {
+                "old": "2000-01-01T00:00:00+00:00",
+                "new": "2026-01-01T00:00:00+00:00",
+            }
+        )
+        # Only two candidates, so the span is fully spent between them: the
+        # newest/oldest land exactly on the configured +/- bound, never past it.
+        assert result["new"] == pytest.approx(1.0 + RECENCY_BOOST_WEIGHT)
+        assert result["old"] == pytest.approx(1.0 - RECENCY_BOOST_WEIGHT)
+
+
+class TestParseUtcTimestamp:
+    """Tests for the private _parse_utc_timestamp helper."""
+
+    def test_parses_z_suffix_as_utc(self):
+        result = retrieval._parse_utc_timestamp("2026-01-01T00:00:00Z")
+        assert result is not None
+        assert result.utcoffset().total_seconds() == 0
+
+    def test_naive_datetime_is_assumed_utc(self):
+        result = retrieval._parse_utc_timestamp("2026-01-01T00:00:00")
+        assert result is not None
+        assert result.utcoffset().total_seconds() == 0
+
+    def test_none_returns_none(self):
+        assert retrieval._parse_utc_timestamp(None) is None
+
+    def test_empty_string_returns_none(self):
+        assert retrieval._parse_utc_timestamp("") is None
+
+    def test_garbage_string_returns_none(self):
+        assert retrieval._parse_utc_timestamp("not-a-timestamp") is None
+
+
+class TestBlendConfidenceAndRecency:
+    """Prove confidence and recency reorder fused RRF candidates predictably."""
+
+    def test_equal_confidence_and_recency_preserves_rrf_order(self):
+        combined = [("r1", 0.02, ["semantic"]), ("r2", 0.01, ["fts"])]
+        result = blend_confidence_and_recency(
+            combined,
+            confidence_by_id={"r1": 0.5, "r2": 0.5},
+            updated_at_by_id={
+                "r1": "2026-01-01T00:00:00+00:00",
+                "r2": "2026-01-01T00:00:00+00:00",
+            },
+        )
+        assert [record_id for record_id, _score, _sources in result] == ["r1", "r2"]
+
+    def test_higher_confidence_can_overturn_a_lower_rrf_rank(self):
+        # r2 trails r1 on raw RRF score, but r1 has been repeatedly marked wrong
+        # (confidence 0.0) while r2 is fully confirmed (confidence 1.0).
+        combined = [("r1", 0.02, ["semantic"]), ("r2", 0.015, ["semantic"])]
+        result = blend_confidence_and_recency(
+            combined,
+            confidence_by_id={"r1": 0.0, "r2": 1.0},
+            updated_at_by_id={
+                "r1": "2026-01-01T00:00:00+00:00",
+                "r2": "2026-01-01T00:00:00+00:00",
+            },
+        )
+        assert result[0][0] == "r2"
+
+    def test_recency_can_overturn_a_close_rrf_rank(self):
+        combined = [("older", 0.0105, ["semantic"]), ("newer", 0.01, ["semantic"])]
+        result = blend_confidence_and_recency(
+            combined,
+            confidence_by_id={"older": 0.5, "newer": 0.5},
+            updated_at_by_id={
+                "older": "2020-01-01T00:00:00+00:00",
+                "newer": "2026-01-01T00:00:00+00:00",
+            },
+        )
+        assert result[0][0] == "newer"
+
+    def test_missing_metadata_defaults_to_neutral(self):
+        combined = [("r1", 0.02, ["semantic"])]
+        result = blend_confidence_and_recency(combined, confidence_by_id={}, updated_at_by_id={})
+        assert result[0][1] == pytest.approx(0.02)
+
+    def test_sources_are_preserved(self):
+        combined = [("r1", 0.02, ["semantic", "fts"])]
+        result = blend_confidence_and_recency(
+            combined,
+            confidence_by_id={"r1": 0.5},
+            updated_at_by_id={"r1": "2026-01-01T00:00:00+00:00"},
+        )
+        assert result[0][2] == ["semantic", "fts"]
+
+    def test_result_stays_sorted_descending(self):
+        combined = [
+            ("a", 0.005, ["fts"]),
+            ("b", 0.02, ["semantic"]),
+            ("c", 0.01, ["semantic", "fts"]),
+        ]
+        result = blend_confidence_and_recency(
+            combined,
+            confidence_by_id={"a": 0.9, "b": 0.1, "c": 0.5},
+            updated_at_by_id={
+                "a": "2026-01-01T00:00:00+00:00",
+                "b": "2026-01-01T00:00:00+00:00",
+                "c": "2026-01-01T00:00:00+00:00",
+            },
+        )
+        scores = [score for _record_id, score, _sources in result]
+        assert scores == sorted(scores, reverse=True)
+
+    def test_empty_combined_returns_empty(self):
+        assert blend_confidence_and_recency([], confidence_by_id={}, updated_at_by_id={}) == []
+
+
+class TestApplyRelevanceFloor:
+    """Prove the relevance floor drops weak candidates instead of forcing top-k."""
+
+    def test_all_irrelevant_candidates_are_excluded(self):
+        reranked = [
+            ("r1", RELEVANCE_FLOOR / 100, ["semantic"]),
+            ("r2", RELEVANCE_FLOOR / 50, ["fts"]),
+            ("r3", 0.0, ["semantic"]),
+        ]
+        assert apply_relevance_floor(reranked) == []
+
+    def test_relevant_candidates_survive(self):
+        reranked = [("r1", RELEVANCE_FLOOR * 10, ["semantic"])]
+        assert apply_relevance_floor(reranked) == reranked
+
+    def test_mixed_set_keeps_only_qualifying_candidates(self):
+        reranked = [
+            ("strong", RELEVANCE_FLOOR * 5, ["semantic", "fts"]),
+            ("weak", RELEVANCE_FLOOR / 10, ["semantic"]),
+        ]
+        result = apply_relevance_floor(reranked)
+        assert [record_id for record_id, _score, _sources in result] == ["strong"]
+
+    def test_boundary_score_is_inclusive(self):
+        reranked = [("r1", RELEVANCE_FLOOR, ["semantic"])]
+        assert apply_relevance_floor(reranked) == reranked
+
+    def test_empty_input_returns_empty(self):
+        assert apply_relevance_floor([]) == []
+
+    def test_preserves_order_of_survivors(self):
+        reranked = [
+            ("first", RELEVANCE_FLOOR * 9, ["semantic"]),
+            ("second", RELEVANCE_FLOOR * 3, ["fts"]),
+        ]
+        assert apply_relevance_floor(reranked) == reranked
+
+
+class TestBlendAndFloorTogether:
+    """The composed pipeline search_records actually runs: blend, then floor."""
+
+    def test_all_deep_tail_candidates_are_excluded(self):
+        # Every candidate is a weak, low-confidence, stale, single-source match --
+        # exactly the "nothing here is a real match" scenario the floor exists for.
+        combined = [(f"tail{i}", RELEVANCE_FLOOR * 0.3, ["semantic"]) for i in range(5)]
+        confidence_by_id = {f"tail{i}": 0.1 for i in range(5)}
+        updated_at_by_id = {f"tail{i}": "2015-01-01T00:00:00+00:00" for i in range(5)}
+
+        reranked = blend_confidence_and_recency(
+            combined,
+            confidence_by_id=confidence_by_id,
+            updated_at_by_id=updated_at_by_id,
+        )
+
+        assert apply_relevance_floor(reranked) == []
+
+    def test_one_strong_candidate_survives_alongside_weak_ones(self):
+        combined = [
+            ("strong", RELEVANCE_FLOOR * 20, ["semantic", "fts"]),
+            ("weak", RELEVANCE_FLOOR * 0.2, ["semantic"]),
+        ]
+        reranked = blend_confidence_and_recency(
+            combined,
+            confidence_by_id={"strong": 0.5, "weak": 0.5},
+            updated_at_by_id={
+                "strong": "2026-01-01T00:00:00+00:00",
+                "weak": "2026-01-01T00:00:00+00:00",
+            },
+        )
+
+        result = apply_relevance_floor(reranked)
+
+        assert [record_id for record_id, _score, _sources in result] == ["strong"]
+
+
+class TestConfidenceAndRecencyThroughRealFusedRanking:
+    """Confidence/recency change the order of a real rrf_fuse() output.
+
+    RRF_K=60 keeps the score gap between adjacent top ranks small (~1.6%, see
+    RRF_K's docstring), which is precisely what lets a mild confidence or
+    recency adjustment flip a close call -- these tests exercise that directly
+    against rrf_fuse's real output rather than hand-built scores.
+    """
+
+    def test_confidence_reorders_a_real_fused_ranking(self):
+        # r1 wins on raw RRF (present in both retrievers' rank 1); r2 only
+        # appears once, at rank 2. Confidence should still flip the winner.
+        combined = rrf_fuse(
+            semantic_rows=[("r1", 0.0), ("r2", 0.1)],
+            lexical_rows=[("r1", -5.0)],
+            semantic_weight=DEFAULT_SEMANTIC_RRF_WEIGHT,
+            lexical_weight=DEFAULT_LEXICAL_RRF_WEIGHT,
+        )
+        assert combined[0][0] == "r1"  # sanity check: raw RRF prefers r1
+
+        reranked = blend_confidence_and_recency(
+            combined,
+            confidence_by_id={"r1": 0.0, "r2": 1.0},
+            updated_at_by_id={
+                "r1": "2026-01-01T00:00:00+00:00",
+                "r2": "2026-01-01T00:00:00+00:00",
+            },
+        )
+
+        assert reranked[0][0] == "r2"
+
+    def test_recency_reorders_a_real_fused_ranking(self):
+        # rank1_id barely beats rank2_id on raw RRF (adjacent single-source
+        # ranks), but rank2_id is far more recently touched.
+        combined = rrf_fuse(
+            semantic_rows=[("rank1_id", 0.0), ("rank2_id", 0.1)],
+            lexical_rows=[],
+            semantic_weight=DEFAULT_SEMANTIC_RRF_WEIGHT,
+            lexical_weight=DEFAULT_LEXICAL_RRF_WEIGHT,
+        )
+        assert combined[0][0] == "rank1_id"  # sanity check: raw RRF prefers rank1_id
+
+        reranked = blend_confidence_and_recency(
+            combined,
+            confidence_by_id={"rank1_id": 0.5, "rank2_id": 0.5},
+            updated_at_by_id={
+                "rank1_id": "2020-01-01T00:00:00+00:00",
+                "rank2_id": "2026-01-01T00:00:00+00:00",
+            },
+        )
+
+        assert reranked[0][0] == "rank2_id"
+
+
+class TestRelevanceFloorAtRealisticShortlistDepth:
+    """The floor must have real teeth at the shipped default shortlist depth.
+
+    Regression coverage for a calibration bug: RELEVANCE_FLOOR was originally
+    5% of an idealized rank-1-in-both-retrievers ceiling, which turned out to
+    be *larger* than the score a maximally weak candidate can still reach
+    within a realistic shortlist -- RRF's rank-based score decays gently by
+    design (see RRF_K), so a candidate ranked dead last within a full
+    RELEVANCE_FLOOR_REFERENCE_RANK-deep shortlist (the shipped default
+    `semantic_shortlist_size` / `lexical_shortlist_size`, see
+    config/default.toml) still keeps a surprisingly large share of the
+    ceiling. These tests build scores through the real rrf_fuse ->
+    blend_confidence_and_recency -> apply_relevance_floor pipeline at that
+    shortlist depth, rather than hand-picked multiples of RELEVANCE_FLOOR, so
+    a future miscalibration fails a test derived from realistic scores
+    instead of one derived from the same constant it is checking.
+    """
+
+    def _fused_at_reference_depth(
+        self, weak_record_id: str
+    ) -> list[tuple[str, float, list[str]]]:
+        """Real rrf_fuse() output: `weak_record_id` ranked dead last in the
+        semantic retriever alone, within a full RELEVANCE_FLOOR_REFERENCE_RANK
+        deep shortlist (the only other retriever this candidate is absent
+        from -- fts -- contributes nothing for it)."""
+        filler_count = RELEVANCE_FLOOR_REFERENCE_RANK - 1
+        semantic_rows = [(f"filler{i}", float(i)) for i in range(filler_count)] + [
+            (weak_record_id, float(filler_count))
+        ]
+        return rrf_fuse(
+            semantic_rows=semantic_rows,
+            lexical_rows=[],
+            semantic_weight=DEFAULT_SEMANTIC_RRF_WEIGHT,
+            lexical_weight=DEFAULT_LEXICAL_RRF_WEIGHT,
+        )
+
+    def test_dead_last_discredited_stale_candidate_is_excluded(self):
+        combined = self._fused_at_reference_depth("weakest")
+        assert combined[-1][0] == "weakest"  # sanity: it really is ranked last
+
+        confidence_by_id = {record_id: 0.5 for record_id, _score, _sources in combined}
+        confidence_by_id["weakest"] = 0.0  # repeatedly marked wrong
+        updated_at_by_id = {
+            record_id: "2026-01-01T00:00:00+00:00" for record_id, _score, _sources in combined
+        }
+        updated_at_by_id["weakest"] = "2015-01-01T00:00:00+00:00"  # oldest -> max staleness
+
+        reranked = blend_confidence_and_recency(
+            combined, confidence_by_id=confidence_by_id, updated_at_by_id=updated_at_by_id
+        )
+        result = apply_relevance_floor(reranked)
+
+        assert "weakest" not in [record_id for record_id, _score, _sources in result]
+
+    def test_dead_last_but_merely_unconfirmed_candidate_still_survives(self):
+        # Guards against over-tuning in the other direction: a candidate at
+        # the same rock-bottom rank that is only unconfirmed (default
+        # confidence) and not stale must still clear the floor. The floor is
+        # meant to catch weak rank combined with active distrust/staleness,
+        # not weak rank alone.
+        combined = self._fused_at_reference_depth("plain")
+
+        confidence_by_id = {record_id: DEFAULT_RECORD_CONFIDENCE for record_id, _score, _sources in combined}
+        updated_at_by_id = {
+            record_id: "2026-01-01T00:00:00+00:00" for record_id, _score, _sources in combined
+        }
+
+        reranked = blend_confidence_and_recency(
+            combined, confidence_by_id=confidence_by_id, updated_at_by_id=updated_at_by_id
+        )
+        result = apply_relevance_floor(reranked)
+
+        assert "plain" in [record_id for record_id, _score, _sources in result]
+
+
+class TestSearchHitConfidenceField:
+    """SearchHit gained a `confidence` field so callers can see earned confidence."""
+
+    def test_confidence_defaults_to_the_spec_default(self):
+        hit = SearchHit(**_base_hit_kwargs())
+        assert hit.confidence == pytest.approx(DEFAULT_RECORD_CONFIDENCE)
+
+    def test_confidence_can_be_set_explicitly(self):
+        hit = SearchHit(confidence=0.9, **_base_hit_kwargs())
+        assert hit.confidence == pytest.approx(0.9)
+
+    def test_confidence_is_frozen(self):
+        hit = SearchHit(**_base_hit_kwargs())
+        with pytest.raises(FrozenInstanceError):
+            hit.confidence = 0.1
+
+    def test_constructing_without_confidence_kwarg_still_works(self):
+        # Existing call sites (e.g. tests/unit/context/test_store_search.py)
+        # construct SearchHit without a `confidence` kwarg; that must keep working.
+        hit = SearchHit(**_base_hit_kwargs())
+        assert hit.record_id == "rec_1"
+
+
+class _RankOrderProvider:
+    """Deterministic fake embeddings for TestSearchRecordsThroughLiveStore.
+
+    `dominant` embeds identically to the query (semantic distance 0);
+    `secondary` embeds further away but still on the same side of the space --
+    a real, if weaker, semantic match. This gives raw RRF one unambiguous
+    winner before any confidence adjustment.
+    """
+
+    model_id = "test-embed-rank-order"
+    embedding_dims = 4
+
+    def embed_query(self, text: str) -> list[float]:
+        """Return a fixed query vector so document similarity is controllable."""
+        del text
+        return [1.0, 0.0, 0.0, 0.0]
+
+    def embed_document(self, text: str) -> list[float]:
+        """Return the dominant, secondary, or a neutral fallback vector."""
+        lowered = text.lower()
+        if "dominant marker" in lowered:
+            return [1.0, 0.0, 0.0, 0.0]
+        if "secondary marker" in lowered:
+            return [0.6, 0.8, 0.0, 0.0]
+        return [0.0, 0.0, 0.0, 1.0]
+
+
+class TestSearchRecordsThroughLiveStore:
+    """One end-to-end proof that Task 1's restructuring actually holds.
+
+    search_records must fetch confidence/recency metadata and rerank the FULL
+    fused candidate set BEFORE slicing to `limit`, not after. The pure-function
+    tests elsewhere in this file already prove blend_confidence_and_recency and
+    apply_relevance_floor work correctly in isolation; this test proves the
+    wiring in search_records actually carries a trailing, confidence-boosted
+    candidate through to a live ContextStore.search() result at a tight limit.
+    If search_records ever regressed to slicing before fetching confidence,
+    this is the test that would catch it: the confidence-boosted record would
+    already be gone before it could win. Broader end-to-end ranking validation
+    across more scenarios is the lead's job.
+    """
+
+    def _build_store(self, tmp_path, monkeypatch):
+        """Build a ContextStore with one registered project and a fake embedder."""
+        monkeypatch.setattr(
+            "lerim.context.store.get_embedding_provider",
+            lambda: _RankOrderProvider(),
+        )
+        db_path = tmp_path / "context.sqlite3"
+        store = ContextStore(db_path)
+        repo_root = tmp_path / "repo"
+        repo_root.mkdir()
+        identity = resolve_project_identity(repo_root)
+        store.initialize()
+        store.register_project(identity)
+        store.upsert_session(
+            project_id=identity.project_id,
+            session_id="sess_search",
+            agent_type="test",
+            source_trace_ref="seed:search",
+            repo_path=str(repo_root),
+            cwd=str(repo_root),
+            started_at="2026-04-18T00:00:00+00:00",
+            model_name="test-model",
+            instructions_text=None,
+            prompt_text=None,
+            metadata={},
+        )
+        return store, identity.project_id
+
+    def test_confidence_boosted_trailing_record_wins_at_a_tight_limit(
+        self, tmp_path, monkeypatch
+    ):
+        store, pid = self._build_store(tmp_path, monkeypatch)
+
+        dominant = store.create_record(
+            project_id=pid,
+            session_id="sess_search",
+            kind="fact",
+            title="Dominant marker record",
+            body=(
+                "Dominant marker record repeats redis cache expiration "
+                "redis cache expiration for a strong raw match."
+            ),
+        )
+        secondary = store.create_record(
+            project_id=pid,
+            session_id="sess_search",
+            kind="fact",
+            title="Secondary marker record",
+            body="Secondary marker record mentions redis cache expiration only once, in passing.",
+        )
+
+        # Pin both records to the same updated_at so recency cannot be the
+        # thing that reorders them below -- confidence must do the work.
+        with store.connect() as conn:
+            conn.execute(
+                "UPDATE records SET updated_at = ? WHERE record_id IN (?, ?)",
+                (
+                    "2026-01-01T00:00:00+00:00",
+                    dominant["record_id"],
+                    secondary["record_id"],
+                ),
+            )
+
+        baseline = store.search(project_ids=[pid], query="redis cache expiration", limit=1)
+        assert baseline[0].record_id == dominant["record_id"]  # sanity: raw RRF favors dominant
+
+        # Discredit the raw winner and fully confirm the trailing record.
+        with store.connect() as conn:
+            conn.execute(
+                "UPDATE records SET confidence = ? WHERE record_id = ?",
+                (0.0, dominant["record_id"]),
+            )
+            conn.execute(
+                "UPDATE records SET confidence = ? WHERE record_id = ?",
+                (1.0, secondary["record_id"]),
+            )
+
+        hits = store.search(project_ids=[pid], query="redis cache expiration", limit=1)
+
+        assert hits[0].record_id == secondary["record_id"]

--- a/tests/unit/context/test_store_confidence.py
+++ b/tests/unit/context/test_store_confidence.py
@@ -1,0 +1,502 @@
+"""Unit tests for the records.confidence migration and per-record feedback."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from unittest.mock import MagicMock
+
+import pytest
+
+from lerim.context.spec import (
+    ALLOWED_FEEDBACK_SIGNALS,
+    FEEDBACK_CONFIDENCE_DELTAS,
+    next_record_confidence,
+    normalize_feedback_signal,
+)
+from lerim.context.store import ContextStore
+
+
+@pytest.fixture
+def mock_embeddings(monkeypatch):
+    """Deterministic embedding provider stub so tests avoid real model calls."""
+    provider = MagicMock()
+    provider.embedding_dims = 384
+    provider.model_id = "test-model"
+    provider.embed_document.return_value = [0.1] * 384
+    provider.embed_query.return_value = [0.1] * 384
+    monkeypatch.setattr("lerim.context.store.get_embedding_provider", lambda: provider)
+    return provider
+
+
+@pytest.fixture
+def mock_store(tmp_path, mock_embeddings):
+    """Fresh ContextStore with an initialized schema."""
+    db_path = tmp_path / "context.sqlite3"
+    s = ContextStore(db_path)
+    s.initialize()
+    return s
+
+
+@pytest.fixture
+def project_id(tmp_path, monkeypatch):
+    """Deterministic project identity for tests."""
+    monkeypatch.setattr(
+        "lerim.config.project_scope.git_root_for",
+        lambda _p=None: tmp_path,
+    )
+    from lerim.context.project_identity import resolve_project_identity
+
+    return resolve_project_identity(tmp_path)
+
+
+@pytest.fixture
+def mock_seeded(mock_store, project_id):
+    """Store with a registered project and one seeded session."""
+    mock_store.register_project(project_id)
+    mock_store.upsert_session(
+        project_id=project_id.project_id,
+        session_id="sess_test",
+        agent_type="test",
+        source_trace_ref="test.jsonl",
+        repo_path=str(project_id.repo_path),
+        cwd=str(project_id.repo_path),
+        started_at="2026-01-01T00:00:00Z",
+        model_name="test-model",
+        instructions_text=None,
+        prompt_text=None,
+    )
+    return mock_store, project_id.project_id
+
+
+def _make_fact(store, project_id, **overrides):
+    """Create a minimal fact record for feedback tests."""
+    defaults = dict(
+        project_id=project_id,
+        session_id="sess_test",
+        kind="fact",
+        title="Confidence test fact",
+        body="Feedback should earn or spend confidence deterministically.",
+    )
+    defaults.update(overrides)
+    return store.create_record(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# spec.py: FeedbackSignal / normalize_feedback_signal / next_record_confidence
+# ---------------------------------------------------------------------------
+
+
+class TestFeedbackSignalSpec:
+    """Pure-function tests for the feedback signal contract in spec.py."""
+
+    def test_allowed_feedback_signals(self):
+        assert set(ALLOWED_FEEDBACK_SIGNALS) == {"used", "correct", "wrong", "confirm"}
+
+    def test_normalize_accepts_allowed_values(self):
+        for signal in ALLOWED_FEEDBACK_SIGNALS:
+            assert normalize_feedback_signal(signal) == signal
+
+    def test_normalize_is_case_and_whitespace_insensitive(self):
+        assert normalize_feedback_signal(" CORRECT ") == "correct"
+
+    def test_normalize_rejects_unknown_signal(self):
+        with pytest.raises(ValueError, match="invalid_feedback_signal:bogus"):
+            normalize_feedback_signal("bogus")
+
+    def test_normalize_rejects_empty_signal(self):
+        with pytest.raises(ValueError, match="invalid_feedback_signal:"):
+            normalize_feedback_signal("")
+
+    @pytest.mark.parametrize(
+        ("signal", "expected_delta"),
+        [("correct", 0.15), ("confirm", 0.15), ("used", 0.05), ("wrong", -0.25)],
+    )
+    def test_confidence_deltas(self, signal, expected_delta):
+        assert FEEDBACK_CONFIDENCE_DELTAS[signal] == expected_delta
+
+    def test_next_record_confidence_applies_delta(self):
+        assert next_record_confidence(0.5, "correct") == pytest.approx(0.65)
+        assert next_record_confidence(0.5, "confirm") == pytest.approx(0.65)
+        assert next_record_confidence(0.5, "used") == pytest.approx(0.55)
+        assert next_record_confidence(0.5, "wrong") == pytest.approx(0.25)
+
+    def test_next_record_confidence_clamps_upper_bound(self):
+        assert next_record_confidence(0.95, "correct") == pytest.approx(1.0)
+
+    def test_next_record_confidence_clamps_lower_bound(self):
+        assert next_record_confidence(0.1, "wrong") == pytest.approx(0.0)
+
+    def test_next_record_confidence_rejects_invalid_signal(self):
+        with pytest.raises(ValueError, match="invalid_feedback_signal:nope"):
+            next_record_confidence(0.5, "nope")
+
+
+# ---------------------------------------------------------------------------
+# store.py: _ensure_record_confidence_schema migration
+# ---------------------------------------------------------------------------
+
+
+class TestEnsureRecordConfidenceSchema:
+    """Tests for the records.confidence column migration."""
+
+    def test_fresh_store_has_confidence_column_with_default(self, mock_store):
+        with mock_store.connect() as conn:
+            columns = mock_store._table_columns(conn, "records")
+        assert "confidence" in columns
+
+    def test_migration_adds_column_and_defaults_existing_rows(self, mock_seeded):
+        store, pid = mock_seeded
+        rec = _make_fact(store, pid)
+        # Simulate a database created before the confidence column existed by
+        # dropping it from an otherwise fully-migrated, populated database.
+        with store.connect() as conn:
+            conn.execute("ALTER TABLE records DROP COLUMN confidence")
+            columns_before = store._table_columns(conn, "records")
+        assert "confidence" not in columns_before
+
+        # Re-run initialize(): this is the real upgrade path a pre-existing
+        # on-disk database goes through, unmodified from production code.
+        store.initialize()
+
+        with store.connect() as conn:
+            columns_after = store._table_columns(conn, "records")
+            row = conn.execute(
+                "SELECT confidence FROM records WHERE record_id = ?",
+                (rec["record_id"],),
+            ).fetchone()
+        assert "confidence" in columns_after
+        assert row["confidence"] == pytest.approx(0.5)
+
+    def test_migration_idempotent(self, mock_store):
+        mock_store.initialize()
+        mock_store.initialize()
+        with mock_store.connect() as conn:
+            columns = mock_store._table_columns(conn, "records")
+        assert "confidence" in columns
+
+    def test_validate_schema_passes_with_confidence_column(self, mock_store):
+        with mock_store.connect() as conn:
+            mock_store._validate_schema(conn)  # must not raise
+
+    def test_record_feedback_table_exists_after_initialize(self, mock_store):
+        with mock_store.connect() as conn:
+            assert mock_store._table_exists(conn, "record_feedback")
+
+    def test_version_row_defaults_confidence_since_it_is_not_versioned(
+        self, mock_seeded
+    ):
+        store, pid = mock_seeded
+        rec = _make_fact(store, pid)
+        store.record_feedback(rec["record_id"], "correct")
+        fetched = store.fetch_record(rec["record_id"], include_versions=True)
+        # record_versions has no confidence column, so version snapshots always
+        # report the default -- confidence is not versioned history.
+        assert fetched["versions"][0]["confidence"] == pytest.approx(0.5)
+        assert fetched["confidence"] == pytest.approx(0.65)
+
+
+# ---------------------------------------------------------------------------
+# store.py: ContextStore.record_feedback
+# ---------------------------------------------------------------------------
+
+
+class TestRecordFeedback:
+    """Tests for ContextStore.record_feedback."""
+
+    def test_new_record_starts_at_default_confidence(self, mock_seeded):
+        store, pid = mock_seeded
+        rec = _make_fact(store, pid)
+        assert rec["confidence"] == pytest.approx(0.5)
+
+    def test_correct_signal_increases_confidence(self, mock_seeded):
+        store, pid = mock_seeded
+        rec = _make_fact(store, pid)
+        result = store.record_feedback(rec["record_id"], "correct")
+        assert result == {
+            "record_id": rec["record_id"],
+            "confidence": pytest.approx(0.65),
+            "signal": "correct",
+        }
+
+    def test_confirm_signal_increases_confidence(self, mock_seeded):
+        store, pid = mock_seeded
+        rec = _make_fact(store, pid)
+        result = store.record_feedback(rec["record_id"], "confirm")
+        assert result["confidence"] == pytest.approx(0.65)
+
+    def test_used_signal_increases_confidence_slightly(self, mock_seeded):
+        store, pid = mock_seeded
+        rec = _make_fact(store, pid)
+        result = store.record_feedback(rec["record_id"], "used")
+        assert result["confidence"] == pytest.approx(0.55)
+
+    def test_wrong_signal_decreases_confidence(self, mock_seeded):
+        store, pid = mock_seeded
+        rec = _make_fact(store, pid)
+        result = store.record_feedback(rec["record_id"], "wrong")
+        assert result["confidence"] == pytest.approx(0.25)
+
+    def test_confidence_clamps_at_upper_bound(self, mock_seeded):
+        store, pid = mock_seeded
+        rec = _make_fact(store, pid)
+        for _ in range(6):
+            result = store.record_feedback(rec["record_id"], "correct")
+        assert result["confidence"] == pytest.approx(1.0)
+
+    def test_confidence_clamps_at_lower_bound(self, mock_seeded):
+        store, pid = mock_seeded
+        rec = _make_fact(store, pid)
+        for _ in range(4):
+            result = store.record_feedback(rec["record_id"], "wrong")
+        assert result["confidence"] == pytest.approx(0.0)
+
+    def test_confidence_persisted_on_records_row(self, mock_seeded):
+        store, pid = mock_seeded
+        rec = _make_fact(store, pid)
+        store.record_feedback(rec["record_id"], "correct")
+        with store.connect() as conn:
+            row = conn.execute(
+                "SELECT confidence FROM records WHERE record_id = ?",
+                (rec["record_id"],),
+            ).fetchone()
+        assert row["confidence"] == pytest.approx(0.65)
+
+    def test_note_and_source_session_id_are_persisted(self, mock_seeded):
+        store, pid = mock_seeded
+        rec = _make_fact(store, pid)
+        store.record_feedback(
+            rec["record_id"],
+            "correct",
+            note="Confirmed during incident review",
+            source_session_id="sess_eval",
+        )
+        events = store.list_feedback(rec["record_id"])
+        assert len(events) == 1
+        assert events[0]["signal"] == "correct"
+        assert events[0]["note"] == "Confirmed during incident review"
+        assert events[0]["source_session_id"] == "sess_eval"
+        assert events[0]["record_id"] == rec["record_id"]
+        assert events[0]["created_at"]
+
+    def test_invalid_signal_raises_before_touching_record(self, mock_seeded):
+        store, pid = mock_seeded
+        rec = _make_fact(store, pid)
+        with pytest.raises(ValueError, match="invalid_feedback_signal:bogus"):
+            store.record_feedback(rec["record_id"], "bogus")
+        # Confidence must be untouched by a rejected signal.
+        refreshed = store.fetch_record(rec["record_id"])
+        assert refreshed["confidence"] == pytest.approx(0.5)
+        assert store.list_feedback(rec["record_id"]) == []
+
+    def test_invalid_signal_checked_before_record_existence(self, mock_seeded):
+        store, _pid = mock_seeded
+        with pytest.raises(ValueError, match="invalid_feedback_signal:bogus"):
+            store.record_feedback("rec_does_not_exist", "bogus")
+
+    def test_unknown_record_raises(self, mock_seeded):
+        store, _pid = mock_seeded
+        with pytest.raises(ValueError, match="record_not_found:rec_missing"):
+            store.record_feedback("rec_missing", "correct")
+
+    def test_does_not_add_record_version_row(self, mock_seeded):
+        store, pid = mock_seeded
+        rec = _make_fact(store, pid)
+        with store.connect() as conn:
+            before = conn.execute(
+                "SELECT COUNT(*) FROM record_versions WHERE record_id = ?",
+                (rec["record_id"],),
+            ).fetchone()[0]
+
+        store.record_feedback(rec["record_id"], "correct")
+
+        with store.connect() as conn:
+            after = conn.execute(
+                "SELECT COUNT(*) FROM record_versions WHERE record_id = ?",
+                (rec["record_id"],),
+            ).fetchone()[0]
+        assert before == after == 1
+
+    def test_does_not_bump_records_index_generation(self, mock_seeded):
+        store, pid = mock_seeded
+        rec = _make_fact(store, pid)
+        with store.connect() as conn:
+            generation_before = store._records_index_generation(conn)
+
+        store.record_feedback(rec["record_id"], "correct")
+
+        with store.connect() as conn:
+            generation_after = store._records_index_generation(conn)
+        assert generation_before == generation_after
+
+
+# ---------------------------------------------------------------------------
+# store.py: regression tests for the reviewer-confirmed 0.0-confidence
+# corruption and the record_feedback read-modify-write race.
+# ---------------------------------------------------------------------------
+
+
+class TestConfidenceZeroFloorRegression:
+    """Regression tests for the `... or DEFAULT_RECORD_CONFIDENCE` bug.
+
+    `_record_row_to_dict` and `record_feedback` used to read a record's
+    confidence with a plain `or DEFAULT_RECORD_CONFIDENCE` fallback, which
+    treats a genuinely earned `0.0` as falsy and silently substitutes `0.5`.
+    That corrupted every reader built on `_record_row_to_dict` (`fetch_record`,
+    `query`) once a record's confidence reached the true floor, and it fed a
+    phantom `0.5` baseline into the *next* `record_feedback` call instead of
+    the real `0.0`. These tests drive a record to the true floor and assert
+    every reader -- and the next feedback computation -- sees `0.0`, not `0.5`.
+    """
+
+    def test_five_consecutive_wrong_signals_clamp_and_stay_at_floor(
+        self, mock_seeded
+    ):
+        """Reproduces the reviewer's exact 5-call trace at the fixed floor."""
+        store, pid = mock_seeded
+        rec = _make_fact(store, pid)
+
+        confidences = [
+            store.record_feedback(rec["record_id"], "wrong")["confidence"]
+            for _ in range(5)
+        ]
+
+        # Buggy behavior oscillated forever: [0.25, 0.0, 0.25, 0.0, 0.25].
+        # Correct behavior clamps at the floor and stays there.
+        assert confidences == pytest.approx([0.25, 0.0, 0.0, 0.0, 0.0])
+
+    def test_fetch_record_reads_back_true_zero_not_phantom_default(
+        self, mock_seeded
+    ):
+        """`fetch_record` must report an earned 0.0, not the 0.5 default."""
+        store, pid = mock_seeded
+        rec = _make_fact(store, pid)
+        store.record_feedback(rec["record_id"], "wrong")
+        store.record_feedback(rec["record_id"], "wrong")  # 0.5 -> 0.25 -> 0.0
+
+        refreshed = store.fetch_record(rec["record_id"])
+
+        assert refreshed["confidence"] == pytest.approx(0.0)
+
+    def test_query_records_list_reads_back_true_zero_not_phantom_default(
+        self, mock_seeded
+    ):
+        """`query(records, list)` (CLI/HTTP/MCP list path) must see the real 0.0."""
+        store, pid = mock_seeded
+        rec = _make_fact(store, pid)
+        store.record_feedback(rec["record_id"], "wrong")
+        store.record_feedback(rec["record_id"], "wrong")  # 0.5 -> 0.25 -> 0.0
+
+        payload = store.query(entity="records", mode="list", project_ids=[pid])
+        matches = [
+            row for row in payload["rows"] if row["record_id"] == rec["record_id"]
+        ]
+
+        assert len(matches) == 1
+        assert matches[0]["confidence"] == pytest.approx(0.0)
+
+    def test_feedback_after_floor_recomputes_from_true_zero_not_phantom_half(
+        self, mock_seeded
+    ):
+        """The next feedback call after the floor must recompute from 0.0."""
+        store, pid = mock_seeded
+        rec = _make_fact(store, pid)
+        store.record_feedback(rec["record_id"], "wrong")
+        store.record_feedback(rec["record_id"], "wrong")  # 0.5 -> 0.25 -> 0.0
+        assert store.fetch_record(rec["record_id"])["confidence"] == pytest.approx(0.0)
+
+        # A phantom 0.5 baseline would land this on 0.65 instead of 0.15.
+        result = store.record_feedback(rec["record_id"], "correct")
+
+        assert result["confidence"] == pytest.approx(0.15)
+
+    def test_record_feedback_does_not_read_current_confidence_via_fetch_record(
+        self, mock_seeded, monkeypatch
+    ):
+        """Regression test for the read-modify-write TOCTOU race.
+
+        The current-confidence read must happen on the same locked
+        (`BEGIN IMMEDIATE`) connection as the INSERT+UPDATE, not via a
+        separate `fetch_record()` call that opens its own unlocked
+        connection/transaction beforehand -- otherwise two concurrent
+        `record_feedback` calls for the same record can both read the same
+        stale confidence and the second writer silently clobbers the first.
+        """
+        store, pid = mock_seeded
+        rec = _make_fact(store, pid)
+        original_fetch_record = store.fetch_record
+        calls = []
+
+        def spying_fetch_record(*args, **kwargs):
+            calls.append((args, kwargs))
+            return original_fetch_record(*args, **kwargs)
+
+        monkeypatch.setattr(store, "fetch_record", spying_fetch_record)
+
+        store.record_feedback(rec["record_id"], "correct")
+
+        assert calls == []
+
+    def test_record_feedback_reads_and_writes_confidence_in_one_transaction(
+        self, mock_seeded, monkeypatch
+    ):
+        """A second, structural check on the same TOCTOU fix: exactly one
+        connection/transaction is opened for the read-modify-write itself
+        (a second connection is opened by the unconditional `self.initialize()`
+        call at the top of `record_feedback`, which is unrelated to this race).
+        """
+        store, pid = mock_seeded
+        rec = _make_fact(store, pid)
+        original_connect = store.connect
+        calls = []
+
+        @contextmanager
+        def counting_connect():
+            calls.append(1)
+            with original_connect() as conn:
+                yield conn
+
+        monkeypatch.setattr(store, "connect", counting_connect)
+
+        store.record_feedback(rec["record_id"], "correct")
+
+        assert len(calls) == 2
+
+
+# ---------------------------------------------------------------------------
+# store.py: ContextStore.list_feedback
+# ---------------------------------------------------------------------------
+
+
+class TestListFeedback:
+    """Tests for ContextStore.list_feedback."""
+
+    def test_empty_when_no_feedback_recorded(self, mock_seeded):
+        store, pid = mock_seeded
+        rec = _make_fact(store, pid)
+        assert store.list_feedback(rec["record_id"]) == []
+
+    def test_returns_events_oldest_first(self, mock_seeded):
+        store, pid = mock_seeded
+        rec = _make_fact(store, pid)
+        store.record_feedback(rec["record_id"], "used")
+        store.record_feedback(rec["record_id"], "correct")
+        store.record_feedback(rec["record_id"], "wrong")
+
+        events = store.list_feedback(rec["record_id"])
+
+        assert [event["signal"] for event in events] == ["used", "correct", "wrong"]
+
+    def test_scoped_to_one_record(self, mock_seeded):
+        store, pid = mock_seeded
+        rec_a = _make_fact(store, pid, title="Fact A")
+        rec_b = _make_fact(store, pid, title="Fact B")
+        store.record_feedback(rec_a["record_id"], "correct")
+        store.record_feedback(rec_b["record_id"], "wrong")
+
+        events_a = store.list_feedback(rec_a["record_id"])
+        events_b = store.list_feedback(rec_b["record_id"])
+
+        assert [event["record_id"] for event in events_a] == [rec_a["record_id"]]
+        assert [event["record_id"] for event in events_b] == [rec_b["record_id"]]
+        assert events_a[0]["signal"] == "correct"
+        assert events_b[0]["signal"] == "wrong"

--- a/tests/unit/server/test_api.py
+++ b/tests/unit/server/test_api.py
@@ -36,6 +36,8 @@ from lerim.server.api import (
     api_connect_list,
     api_health,
     api_curate,
+    api_feedback,
+    api_feedback_list,
     api_memory_reset,
     api_project_add,
     api_project_list,
@@ -756,6 +758,178 @@ def test_api_record_filters_accept_project_child_path(
     assert payload["types"] == ["preference"]
     assert payload["roles"] == ["procedure"]
     assert payload["projects"] == ["selected"]
+
+
+# ---------------------------------------------------------------------------
+# api_feedback / api_feedback_list
+# ---------------------------------------------------------------------------
+
+
+def _seed_feedback_record(tmp_path: Path, cfg: Any) -> str:
+    """Seed one registered project and fact record; return its record_id."""
+    project_root = tmp_path / "project"
+    project_root.mkdir(exist_ok=True)
+    identity = resolve_project_identity(project_root)
+    store = ContextStore(cfg.context_db_path)
+    store.initialize()
+    store.register_project(identity)
+    record = store.create_record(
+        project_id=identity.project_id,
+        session_id=None,
+        kind="fact",
+        title="Feedback API test fact",
+        body="api_feedback should reach the real confidence pipeline.",
+    )
+    return record["record_id"]
+
+
+def test_api_feedback_scope_resolution_mirrors_api_query(
+    monkeypatch, tmp_path
+) -> None:
+    """api_feedback resolves scope/project the same way api_query does."""
+    cfg = replace(make_config(tmp_path), projects={"known": str(tmp_path)})
+    monkeypatch.setattr(api_mod, "get_config", lambda: cfg)
+
+    query_payload = api_mod.api_query(entity="records", mode="count", project="missing")
+    feedback_payload = api_feedback("rec_whatever", "correct", project="missing")
+
+    assert feedback_payload["error"] is True
+    assert feedback_payload["message"] == query_payload["message"] == "Project not found: missing"
+    assert feedback_payload["projects_used"] == query_payload["projects_used"] == []
+
+
+def test_api_feedback_success_returns_confidence_and_scope(
+    monkeypatch, tmp_path, mock_embeddings
+) -> None:
+    """A successful feedback call returns confidence, signal, and scope fields."""
+    cfg = replace(make_config(tmp_path), projects={"project": str(tmp_path / "project")})
+    monkeypatch.setattr(api_mod, "get_config", lambda: cfg)
+    record_id = _seed_feedback_record(tmp_path, cfg)
+
+    payload = api_feedback(record_id, "correct", note="Confirmed in review")
+
+    assert payload["error"] is False
+    assert payload["record_id"] == record_id
+    assert payload["signal"] == "correct"
+    assert payload["confidence"] == pytest.approx(0.65)
+    assert payload["projects_used"] == ["project"]
+    assert payload["scope"] == "all"
+
+
+def test_api_feedback_project_scoped_success_reports_projects_used(
+    monkeypatch, tmp_path, mock_embeddings
+) -> None:
+    """Project-scoped feedback calls still report the resolved project name."""
+    cfg = replace(make_config(tmp_path), projects={"project": str(tmp_path / "project")})
+    monkeypatch.setattr(api_mod, "get_config", lambda: cfg)
+    record_id = _seed_feedback_record(tmp_path, cfg)
+
+    payload = api_feedback(record_id, "used", project="project")
+
+    assert payload["error"] is False
+    assert payload["scope"] == "project"
+    assert payload["projects_used"] == ["project"]
+    assert payload["confidence"] == pytest.approx(0.55)
+
+
+def test_api_feedback_invalid_signal_returns_bad_request(
+    monkeypatch, tmp_path, mock_embeddings
+) -> None:
+    """An invalid signal is surfaced as a 400-shaped error."""
+    cfg = replace(make_config(tmp_path), projects={"project": str(tmp_path / "project")})
+    monkeypatch.setattr(api_mod, "get_config", lambda: cfg)
+    record_id = _seed_feedback_record(tmp_path, cfg)
+
+    payload = api_feedback(record_id, "bogus")
+
+    assert payload["error"] is True
+    assert payload["status_code"] == 400
+    assert payload["message"] == "invalid_feedback_signal:bogus"
+
+
+def test_api_feedback_unknown_record_returns_bad_request(
+    monkeypatch, tmp_path
+) -> None:
+    """An unknown record_id is surfaced as a 400-shaped error, not a crash."""
+    cfg = make_config(tmp_path)
+    monkeypatch.setattr(api_mod, "get_config", lambda: cfg)
+
+    payload = api_feedback("rec_missing", "correct")
+
+    assert payload["error"] is True
+    assert payload["status_code"] == 400
+    assert payload["message"] == "record_not_found:rec_missing"
+
+
+def test_api_feedback_storage_error_returns_structured_failure(
+    monkeypatch, tmp_path
+) -> None:
+    """A storage failure while recording feedback is reported, not raised."""
+    cfg = make_config(tmp_path)
+    monkeypatch.setattr(api_mod, "get_config", lambda: cfg)
+
+    class BrokenStore:
+        def record_feedback(self, *args, **kwargs):
+            raise sqlite3.OperationalError("database is locked")
+
+    monkeypatch.setattr(api_mod, "_context_store", lambda config: BrokenStore())
+
+    payload = api_feedback("rec_whatever", "correct")
+
+    assert payload["error"] is True
+    assert payload["status_code"] == 503
+    assert payload["message"] == "Context query storage is unavailable."
+
+
+def test_api_feedback_list_returns_rows(monkeypatch, tmp_path, mock_embeddings) -> None:
+    """api_feedback_list returns recorded feedback events for one record."""
+    cfg = replace(make_config(tmp_path), projects={"project": str(tmp_path / "project")})
+    monkeypatch.setattr(api_mod, "get_config", lambda: cfg)
+    record_id = _seed_feedback_record(tmp_path, cfg)
+    api_feedback(record_id, "used")
+    api_feedback(record_id, "correct")
+
+    payload = api_feedback_list(record_id)
+
+    assert payload["error"] is False
+    assert payload["record_id"] == record_id
+    assert payload["count"] == 2
+    assert [row["signal"] for row in payload["rows"]] == ["used", "correct"]
+
+
+def test_api_feedback_list_empty_for_record_without_feedback(
+    monkeypatch, tmp_path, mock_embeddings
+) -> None:
+    """api_feedback_list returns an empty row list when no feedback exists."""
+    cfg = replace(make_config(tmp_path), projects={"project": str(tmp_path / "project")})
+    monkeypatch.setattr(api_mod, "get_config", lambda: cfg)
+    record_id = _seed_feedback_record(tmp_path, cfg)
+
+    payload = api_feedback_list(record_id)
+
+    assert payload["error"] is False
+    assert payload["rows"] == []
+    assert payload["count"] == 0
+
+
+def test_api_feedback_list_storage_error_returns_structured_failure(
+    monkeypatch, tmp_path
+) -> None:
+    """A storage failure while listing feedback is reported, not raised."""
+    cfg = make_config(tmp_path)
+    monkeypatch.setattr(api_mod, "get_config", lambda: cfg)
+
+    class BrokenStore:
+        def list_feedback(self, *args, **kwargs):
+            raise sqlite3.OperationalError("database is locked")
+
+    monkeypatch.setattr(api_mod, "_context_store", lambda config: BrokenStore())
+
+    payload = api_feedback_list("rec_whatever")
+
+    assert payload["error"] is True
+    assert payload["status_code"] == 503
+    assert payload["message"] == "Context query storage is unavailable."
 
 
 def test_api_skill_target_add_scopes_registered_project_paths(

--- a/tests/unit/server/test_cli_feedback.py
+++ b/tests/unit/server/test_cli_feedback.py
@@ -1,0 +1,253 @@
+"""Tests for the `lerim feedback` CLI command.
+
+Covers parser registration/wiring and the `_cmd_feedback` handler with a
+mocked `api_feedback`, plus one end-to-end pass through `cli.main`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+
+import pytest
+
+from lerim.server import cli
+from tests.helpers import run_cli, run_cli_json
+
+
+def _get_subparser_names() -> set[str]:
+    """Extract subcommand names from build_parser()."""
+    parser = cli.build_parser()
+    for action in parser._subparsers._actions:
+        if isinstance(action, argparse._SubParsersAction):
+            return set(action.choices.keys())
+    return set()
+
+
+# ── Parser registration and wiring ───────────────────────────────────
+
+
+def test_feedback_parser_exists() -> None:
+    """'feedback' is registered as a subcommand in build_parser()."""
+    assert "feedback" in _get_subparser_names()
+
+
+def test_feedback_parser_accepts_record_id_and_signal() -> None:
+    """record_id and signal are positional arguments."""
+    parser = cli.build_parser()
+    args = parser.parse_args(["feedback", "rec_abc123", "correct"])
+    assert args.command == "feedback"
+    assert args.record_id == "rec_abc123"
+    assert args.signal == "correct"
+    assert args.note is None
+    assert args.func is cli._cmd_feedback
+
+
+@pytest.mark.parametrize("signal", ["used", "correct", "wrong", "confirm"])
+def test_feedback_parser_accepts_all_allowed_signals(signal: str) -> None:
+    """Every canonical feedback signal is a valid positional choice."""
+    parser = cli.build_parser()
+    args = parser.parse_args(["feedback", "rec_abc123", signal])
+    assert args.signal == signal
+
+
+def test_feedback_parser_rejects_invalid_signal() -> None:
+    """Signals outside the canonical set are rejected by argparse."""
+    parser = cli.build_parser()
+    with pytest.raises(SystemExit) as exc:
+        parser.parse_args(["feedback", "rec_abc123", "bogus"])
+    assert exc.value.code == 2
+
+
+def test_feedback_parser_accepts_note_and_json() -> None:
+    """--note and --json are recognised optional flags."""
+    parser = cli.build_parser()
+    args = parser.parse_args(
+        ["feedback", "rec_abc123", "wrong", "--note", "Reverted in prod", "--json"]
+    )
+    assert args.note == "Reverted in prod"
+    assert args.json is True
+
+
+def test_feedback_parser_requires_record_id_and_signal() -> None:
+    """Both positionals are required."""
+    parser = cli.build_parser()
+    with pytest.raises(SystemExit) as exc:
+        parser.parse_args(["feedback"])
+    assert exc.value.code == 2
+    with pytest.raises(SystemExit) as exc:
+        parser.parse_args(["feedback", "rec_abc123"])
+    assert exc.value.code == 2
+
+
+# ── _cmd_feedback behaviour ───────────────────────────────────────────
+
+
+def test_cmd_feedback_success_json(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A successful feedback call with --json prints the payload and exits 0."""
+    captured: dict[str, object] = {}
+
+    def fake_api_feedback(record_id, signal, *, note=None, source_session_id=None):
+        captured["record_id"] = record_id
+        captured["signal"] = signal
+        captured["note"] = note
+        return {
+            "record_id": record_id,
+            "confidence": 0.65,
+            "signal": signal,
+            "error": False,
+            "projects_used": [],
+            "scope": "all",
+        }
+
+    monkeypatch.setattr(cli, "api_feedback", fake_api_feedback)
+    output: list[str] = []
+    monkeypatch.setattr(cli, "_emit", lambda *a, **kw: output.append(str(a[0]) if a else ""))
+
+    args = argparse.Namespace(
+        record_id="rec_abc123", signal="correct", note="Confirmed", json=True
+    )
+    rc = cli._cmd_feedback(args)
+
+    assert rc == 0
+    assert captured == {"record_id": "rec_abc123", "signal": "correct", "note": "Confirmed"}
+    payload = json.loads("\n".join(output))
+    assert payload["confidence"] == 0.65
+    assert payload["error"] is False
+
+
+def test_cmd_feedback_success_without_json_flag_still_prints_payload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Successful feedback prints the JSON payload even without --json (mirrors query)."""
+    monkeypatch.setattr(
+        cli,
+        "api_feedback",
+        lambda *a, **kw: {
+            "record_id": "rec_abc123",
+            "confidence": 0.55,
+            "signal": "used",
+            "error": False,
+            "projects_used": [],
+            "scope": "all",
+        },
+    )
+    output: list[str] = []
+    monkeypatch.setattr(cli, "_emit", lambda *a, **kw: output.append(str(a[0]) if a else ""))
+
+    args = argparse.Namespace(record_id="rec_abc123", signal="used", note=None, json=False)
+    rc = cli._cmd_feedback(args)
+
+    assert rc == 0
+    payload = json.loads("\n".join(output))
+    assert payload["confidence"] == 0.55
+
+
+def test_cmd_feedback_error_json_returns_one(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A failed feedback call with --json prints the error payload and exits 1."""
+    monkeypatch.setattr(
+        cli,
+        "api_feedback",
+        lambda *a, **kw: {
+            "error": True,
+            "message": "record_not_found:rec_missing",
+            "projects_used": [],
+            "status_code": 400,
+        },
+    )
+    output: list[str] = []
+    monkeypatch.setattr(cli, "_emit", lambda *a, **kw: output.append(str(a[0]) if a else ""))
+
+    args = argparse.Namespace(record_id="rec_missing", signal="correct", note=None, json=True)
+    rc = cli._cmd_feedback(args)
+
+    assert rc == 1
+    payload = json.loads("\n".join(output))
+    assert payload["error"] is True
+    assert payload["message"] == "record_not_found:rec_missing"
+
+
+def test_cmd_feedback_missing_record_error_without_json(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A missing-record error without --json prints the message to stderr and exits 1."""
+    monkeypatch.setattr(
+        cli,
+        "api_feedback",
+        lambda *a, **kw: {
+            "error": True,
+            "message": "record_not_found:rec_missing",
+            "projects_used": [],
+            "status_code": 400,
+        },
+    )
+    stderr_lines: list[str] = []
+    stdout_lines: list[str] = []
+
+    def fake_emit(message="", *, file=None):
+        (stderr_lines if file is not None else stdout_lines).append(str(message))
+
+    monkeypatch.setattr(cli, "_emit", fake_emit)
+
+    args = argparse.Namespace(record_id="rec_missing", signal="correct", note=None, json=False)
+    rc = cli._cmd_feedback(args)
+
+    assert rc == 1
+    assert any("record_not_found:rec_missing" in line for line in stderr_lines)
+    assert stdout_lines == []
+
+
+def test_cmd_feedback_passes_note_through(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The optional --note value reaches api_feedback."""
+    captured: dict[str, object] = {}
+
+    def fake_api_feedback(record_id, signal, *, note=None, source_session_id=None):
+        captured["note"] = note
+        return {"record_id": record_id, "confidence": 0.5, "signal": signal, "error": False}
+
+    monkeypatch.setattr(cli, "api_feedback", fake_api_feedback)
+    monkeypatch.setattr(cli, "_emit", lambda *a, **kw: None)
+
+    args = argparse.Namespace(record_id="rec_abc123", signal="confirm", note=None, json=True)
+    cli._cmd_feedback(args)
+
+    assert captured["note"] is None
+
+
+# ── End-to-end through cli.main ───────────────────────────────────────
+
+
+def test_feedback_end_to_end_through_main(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`lerim feedback <id> <signal> --json` runs through the real argparse + dispatch path."""
+    monkeypatch.setattr(
+        cli,
+        "api_feedback",
+        lambda record_id, signal, **kw: {
+            "record_id": record_id,
+            "confidence": 0.65,
+            "signal": signal,
+            "error": False,
+            "projects_used": [],
+            "scope": "all",
+        },
+    )
+    code, payload = run_cli_json(["feedback", "rec_abc123", "correct", "--json"])
+    assert code == 0
+    assert payload["record_id"] == "rec_abc123"
+    assert payload["confidence"] == 0.65
+
+
+def test_feedback_end_to_end_error_exit_code(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A feedback failure surfaced through cli.main exits non-zero without --json."""
+    monkeypatch.setattr(
+        cli,
+        "api_feedback",
+        lambda *a, **kw: {
+            "error": True,
+            "message": "invalid_feedback_signal:bogus",
+            "projects_used": [],
+            "status_code": 400,
+        },
+    )
+    code, _output = run_cli(["feedback", "rec_abc123", "correct"])
+    assert code == 1

--- a/tests/unit/skill_stewardship/test_artifacts_agents_entry.py
+++ b/tests/unit/skill_stewardship/test_artifacts_agents_entry.py
@@ -1,0 +1,82 @@
+"""Tests for AGENTS.md entry-caliber treatment when co-located with SKILL.md."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from lerim.skill_stewardship.artifacts import scan_instruction_artifact
+
+
+def test_agents_md_gets_entry_role_alongside_skill_md(tmp_path: Path) -> None:
+    """A directory with both SKILL.md and AGENTS.md treats both as entry-caliber."""
+    skill = tmp_path / "skill"
+    skill.mkdir()
+    (skill / "SKILL.md").write_text(
+        "---\nname: demo\ndescription: Demo.\n---\n\nUse small updates.\n",
+        encoding="utf-8",
+    )
+    (skill / "AGENTS.md").write_text(
+        "# Agent Notes\n\nFollow local conventions.\n",
+        encoding="utf-8",
+    )
+
+    _base, manifest, files = scan_instruction_artifact(skill)
+
+    entry_paths = {item.relative_path for item in files if item.file_role == "entry"}
+    assert entry_paths == {"SKILL.md", "AGENTS.md"}
+    # The singular manifest entry pointer stays SKILL.md; only per-file role is upgraded.
+    assert manifest.entry_file == "SKILL.md"
+    assert "AGENTS.md" in manifest.instruction_files
+
+
+def test_agents_md_alone_keeps_existing_single_entry_behavior(tmp_path: Path) -> None:
+    """A directory with only AGENTS.md keeps its existing single-entry behavior."""
+    only_agents = tmp_path / "only-agents"
+    only_agents.mkdir()
+    (only_agents / "AGENTS.md").write_text(
+        "# Project Instructions\n\nRun tests.\n",
+        encoding="utf-8",
+    )
+
+    _base, manifest, files = scan_instruction_artifact(only_agents)
+
+    entry_paths = {item.relative_path for item in files if item.file_role == "entry"}
+    assert entry_paths == {"AGENTS.md"}
+    assert manifest.entry_file == "AGENTS.md"
+
+
+def test_skill_md_alone_keeps_existing_single_entry_behavior(tmp_path: Path) -> None:
+    """A directory with only SKILL.md keeps its existing single-entry behavior."""
+    skill_only = tmp_path / "skill-only"
+    skill_only.mkdir()
+    (skill_only / "SKILL.md").write_text(
+        "---\nname: demo\ndescription: Demo.\n---\n\nUse small updates.\n",
+        encoding="utf-8",
+    )
+
+    _base, manifest, files = scan_instruction_artifact(skill_only)
+
+    entry_paths = {item.relative_path for item in files if item.file_role == "entry"}
+    assert entry_paths == {"SKILL.md"}
+    assert manifest.entry_file == "SKILL.md"
+
+
+def test_agents_md_in_different_directory_is_not_entry_caliber(tmp_path: Path) -> None:
+    """An AGENTS.md that is not a direct sibling of SKILL.md is not promoted."""
+    skill = tmp_path / "skill"
+    references = skill / "references"
+    references.mkdir(parents=True)
+    (skill / "SKILL.md").write_text(
+        "---\nname: demo\ndescription: Demo.\n---\n\nUse small updates.\n",
+        encoding="utf-8",
+    )
+    (references / "AGENTS.md").write_text(
+        "# Nested notes\n\nNot a sibling entry file.\n",
+        encoding="utf-8",
+    )
+
+    _base, manifest, files = scan_instruction_artifact(skill)
+
+    entry_paths = {item.relative_path for item in files if item.file_role == "entry"}
+    assert entry_paths == {"SKILL.md"}
+    assert manifest.entry_file == "SKILL.md"

--- a/tests/unit/skill_stewardship/test_validation_evidence.py
+++ b/tests/unit/skill_stewardship/test_validation_evidence.py
@@ -1,0 +1,221 @@
+"""Tests for store-backed evidence verification in proposal validation and guarding."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from lerim.context import ContextStore
+from lerim.skill_stewardship.artifacts import scan_instruction_artifact
+from lerim.skill_stewardship.pipeline import guard_proposal
+from lerim.skill_stewardship.schemas import AutoApplyPolicy, SkillPatch, SkillProposalDraft
+from lerim.skill_stewardship.validation import validate_proposal
+
+ORIGINAL_SKILL_TEXT = "---\nname: demo\ndescription: Demo.\n---\n\nUse evidence.\n"
+
+
+def _make_record(store: ContextStore, *, title: str, body: str) -> dict[str, Any]:
+    """Create a minimal durable record usable as cited evidence in tests."""
+    return store.create_record(
+        project_id=None,
+        session_id=None,
+        kind="fact",
+        title=title,
+        body=body,
+        scope_type="workspace",
+        scope_id="ws-test",
+        scope_label="workspace",
+    )
+
+
+def _scanned_skill(tmp_path: Path) -> tuple[Path, Any]:
+    """Write and scan one minimal SKILL.md fixture, returning its base and manifest."""
+    skill = tmp_path / "skill"
+    skill.mkdir()
+    (skill / "SKILL.md").write_text(ORIGINAL_SKILL_TEXT, encoding="utf-8")
+    base, manifest, _files = scan_instruction_artifact(skill)
+    return base, manifest
+
+
+def test_validate_proposal_rejects_nonexistent_evidence_record(tmp_path: Path) -> None:
+    """A patch citing a record id that does not exist in the store fails validation."""
+    base, manifest = _scanned_skill(tmp_path)
+    store = ContextStore(tmp_path / "context.sqlite3")
+    draft = SkillProposalDraft(
+        title="Cite missing record",
+        summary="Cites a record id that was never created.",
+        risk_level="low",
+        patches=[
+            SkillPatch(
+                relative_path="SKILL.md",
+                change_type="modify",
+                risk="low",
+                rationale="Claims support from a record that does not exist.",
+                evidence_record_ids=["rec_does_not_exist"],
+                before_text=ORIGINAL_SKILL_TEXT,
+                after_text=ORIGINAL_SKILL_TEXT + "Keep updates small.\n",
+                diff_text="",
+            )
+        ],
+    )
+
+    result = validate_proposal(base_path=base, manifest=manifest, proposal=draft, store=store)
+
+    assert result.ok is False
+    assert any("evidence record not found" in error for error in result.errors)
+
+
+def test_validate_proposal_flags_unsupported_after_text(tmp_path: Path) -> None:
+    """A patch whose new text has nothing to do with its cited record fails validation."""
+    base, manifest = _scanned_skill(tmp_path)
+    store = ContextStore(tmp_path / "context.sqlite3")
+    record = _make_record(
+        store,
+        title="Adopt uv for dependency management",
+        body=(
+            "Adopt uv and lockfile pinning for all Python dependency installs "
+            "to keep environments reproducible."
+        ),
+    )
+    unrelated_addition = (
+        "\n## Deploys\n\nDeploy the frontend using blue-green Kubernetes canary "
+        "rollouts with the Istio service mesh.\n"
+    )
+    draft = SkillProposalDraft(
+        title="Add deployment guidance",
+        summary="Adds unrelated deployment guidance.",
+        risk_level="low",
+        patches=[
+            SkillPatch(
+                relative_path="SKILL.md",
+                change_type="modify",
+                risk="low",
+                rationale="Claims support from a dependency-management record.",
+                evidence_record_ids=[record["record_id"]],
+                before_text=ORIGINAL_SKILL_TEXT,
+                after_text=ORIGINAL_SKILL_TEXT + unrelated_addition,
+                diff_text="",
+            )
+        ],
+    )
+
+    result = validate_proposal(base_path=base, manifest=manifest, proposal=draft, store=store)
+
+    assert result.ok is False
+    assert any("not supported by cited evidence records" in error for error in result.errors)
+
+
+def test_validate_proposal_accepts_supported_after_text(tmp_path: Path) -> None:
+    """A patch whose new text is well supported by its cited record still passes."""
+    base, manifest = _scanned_skill(tmp_path)
+    store = ContextStore(tmp_path / "context.sqlite3")
+    record = _make_record(
+        store,
+        title="Adopt tenacity for API retries",
+        body=(
+            "Use tenacity with exponential backoff and jitter for all outbound API "
+            "retries so we survive upstream rate limits."
+        ),
+    )
+    supported_addition = (
+        "\n## Retries\n\nUse tenacity with exponential backoff and jitter when "
+        "retrying API calls.\n"
+    )
+    draft = SkillProposalDraft(
+        title="Add retry guidance",
+        summary="Documents the retry approach already used in the codebase.",
+        risk_level="low",
+        patches=[
+            SkillPatch(
+                relative_path="SKILL.md",
+                change_type="modify",
+                risk="low",
+                rationale="Supported by the tenacity retry record.",
+                evidence_record_ids=[record["record_id"]],
+                before_text=ORIGINAL_SKILL_TEXT,
+                after_text=ORIGINAL_SKILL_TEXT + supported_addition,
+                diff_text="",
+            )
+        ],
+    )
+
+    result = validate_proposal(base_path=base, manifest=manifest, proposal=draft, store=store)
+
+    assert result.ok is True
+
+
+def test_validate_proposal_without_store_skips_evidence_checks(tmp_path: Path) -> None:
+    """Omitting store keeps validation exactly as before: no existence or support checks."""
+    base, manifest = _scanned_skill(tmp_path)
+    draft = SkillProposalDraft(
+        title="Cite missing record",
+        summary="Cites a record id that was never created.",
+        risk_level="low",
+        patches=[
+            SkillPatch(
+                relative_path="SKILL.md",
+                change_type="modify",
+                risk="low",
+                rationale="Would fail if evidence were checked.",
+                evidence_record_ids=["rec_does_not_exist"],
+                before_text=ORIGINAL_SKILL_TEXT,
+                after_text=ORIGINAL_SKILL_TEXT + "Keep updates small.\n",
+                diff_text="",
+            )
+        ],
+    )
+
+    result = validate_proposal(base_path=base, manifest=manifest, proposal=draft)
+
+    assert result.ok is True
+
+
+def test_guard_proposal_rejects_nonexistent_evidence_record(tmp_path: Path) -> None:
+    """The guard's upgraded evidence gate also rejects citing a record that does not exist."""
+    store = ContextStore(tmp_path / "context.sqlite3")
+    draft = SkillProposalDraft(
+        title="Cite missing record",
+        summary="Cites a record id that was never created.",
+        risk_level="low",
+        patches=[
+            SkillPatch(
+                relative_path="SKILL.md",
+                change_type="modify",
+                risk="low",
+                rationale="Would be caught by the upgraded guard.",
+                evidence_record_ids=["rec_does_not_exist"],
+                after_text="Some new guidance.\n",
+                diff_text="",
+            )
+        ],
+    )
+
+    result = guard_proposal(draft=draft, policy=AutoApplyPolicy(enabled=True), store=store)
+
+    assert result.accepted is False
+    assert result.auto_apply_eligible is False
+    assert any("evidence record not found" in reason for reason in result.reasons)
+
+
+def test_guard_proposal_without_store_only_checks_presence() -> None:
+    """Omitting store keeps the guard's evidence gate presence-only, as before."""
+    draft = SkillProposalDraft(
+        title="Cite missing record",
+        summary="Cites a record id that was never created.",
+        risk_level="low",
+        patches=[
+            SkillPatch(
+                relative_path="SKILL.md",
+                change_type="modify",
+                risk="low",
+                rationale="Would fail if evidence were checked.",
+                evidence_record_ids=["rec_does_not_exist"],
+                after_text="Some new guidance.\n",
+                diff_text="",
+            )
+        ],
+    )
+
+    result = guard_proposal(draft=draft, policy=AutoApplyPolicy(enabled=True))
+
+    assert result.accepted is True

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -55,6 +55,7 @@ def test_create_mcp_server_lists_expected_tools() -> None:
         "lerim_context_answer",
         "lerim_context_search",
         "lerim_records_list",
+        "lerim_context_feedback",
         "lerim_trace_submit",
         "lerim_ingest_status",
     }.issubset(names)
@@ -366,6 +367,113 @@ def test_records_list_tool_clamps_limit_and_offset(monkeypatch: pytest.MonkeyPat
     assert captured["offset"] == 0
     assert captured["kind"] == "decision"
     assert captured["status"] is None
+
+
+def test_context_feedback_tool_requires_record_id() -> None:
+    """A blank record_id is rejected before reaching the API boundary."""
+    tool = _tool_fn("lerim_context_feedback")
+
+    assert tool(record_id="   ", signal="correct") == {
+        "error": True,
+        "message": "record_id_required",
+    }
+
+
+def test_context_feedback_tool_requires_signal() -> None:
+    """A blank signal is rejected before reaching the API boundary."""
+    tool = _tool_fn("lerim_context_feedback")
+
+    assert tool(record_id="rec_test", signal="") == {
+        "error": True,
+        "message": "signal_required",
+    }
+
+
+def test_context_feedback_tool_rejects_unknown_record(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An unknown record_id surfaces the store's record_not_found error."""
+    captured: dict[str, Any] = {}
+
+    def fake_feedback(record_id, signal, **kwargs: Any) -> dict[str, Any]:
+        captured["record_id"] = record_id
+        captured["signal"] = signal
+        return {
+            "error": True,
+            "message": f"record_not_found:{record_id}",
+            "projects_used": [],
+            "status_code": 400,
+        }
+
+    monkeypatch.setattr("lerim.mcp_server.api_feedback", fake_feedback)
+    tool = _tool_fn("lerim_context_feedback")
+
+    payload = tool(record_id="rec_missing", signal="correct")
+
+    assert payload["error"] is True
+    assert payload["message"] == "record_not_found:rec_missing"
+    assert captured == {"record_id": "rec_missing", "signal": "correct"}
+
+
+def test_context_feedback_tool_rejects_invalid_signal(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An invalid signal surfaces the store's validation error."""
+
+    def fake_feedback(record_id, signal, **kwargs: Any) -> dict[str, Any]:
+        return {
+            "error": True,
+            "message": f"invalid_feedback_signal:{signal}",
+            "projects_used": [],
+            "status_code": 400,
+        }
+
+    monkeypatch.setattr("lerim.mcp_server.api_feedback", fake_feedback)
+    tool = _tool_fn("lerim_context_feedback")
+
+    payload = tool(record_id="rec_test", signal="bogus")
+
+    assert payload["error"] is True
+    assert payload["message"] == "invalid_feedback_signal:bogus"
+
+
+def test_context_feedback_tool_succeeds_and_returns_confidence(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The feedback tool reaches the real store and returns updated confidence."""
+    project_dir = tmp_path / "repo"
+    project_dir.mkdir()
+    cfg = replace(
+        make_config(tmp_path / ".lerim"),
+        projects={"repo": str(project_dir)},
+    )
+    monkeypatch.setattr("lerim.mcp_server.get_config", lambda: cfg)
+    monkeypatch.setattr("lerim.server.api.get_config", lambda: cfg)
+    monkeypatch.setattr(
+        "lerim.context.store.get_embedding_provider",
+        lambda: _FakeEmbeddingProvider(),
+    )
+    identity = resolve_project_identity(project_dir)
+    store = ContextStore(cfg.context_db_path)
+    store.register_project(identity)
+    record = store.create_record(
+        project_id=identity.project_id,
+        session_id=None,
+        kind="fact",
+        title="Feedback MCP tool test",
+        body="The feedback tool should reach the real confidence pipeline.",
+    )
+    assert record["confidence"] == pytest.approx(0.5)
+    tool = _tool_fn("lerim_context_feedback")
+
+    payload = tool(record_id=record["record_id"], signal="correct", note="Confirmed live")
+
+    assert payload["error"] is False
+    assert payload["record_id"] == record["record_id"]
+    assert payload["confidence"] == pytest.approx(0.65)
+    assert payload["signal"] == "correct"
+    refreshed = store.fetch_record(record["record_id"])
+    assert refreshed["confidence"] == pytest.approx(0.65)
+    events = store.list_feedback(record["record_id"])
+    assert len(events) == 1
+    assert events[0]["note"] == "Confirmed live"
 
 
 def test_ingest_status_tool_delegates_to_status_api(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/test_redaction.py
+++ b/tests/unit/test_redaction.py
@@ -1,0 +1,221 @@
+"""Unit tests for lerim.redaction: content-based secret and PII scrubbing.
+
+Covers each recognized secret/PII pattern, composite text with several
+secrets at once, and precision checks that ordinary prose and code
+identifiers are left untouched.
+"""
+
+from __future__ import annotations
+
+from lerim.redaction import redact_text
+
+
+# ---------------------------------------------------------------------------
+# Individual secret/PII patterns are redacted
+# ---------------------------------------------------------------------------
+
+
+def test_redacts_openai_style_key():
+    """An OpenAI-style sk- API key is replaced with the api_key placeholder."""
+    text = "export OPENAI_API_KEY=sk-abcdefghijklmnopqrstuvwxyz0123456789"
+    result = redact_text(text)
+    assert "sk-abcdefghijklmnopqrstuvwxyz0123456789" not in result
+    assert "[REDACTED:api_key]" in result
+
+
+def test_redacts_aws_access_key():
+    """An AWS access key id (AKIA...) is replaced with a stable placeholder."""
+    text = "aws_access_key_id = AKIAIOSFODNN7EXAMPLE"
+    result = redact_text(text)
+    assert "AKIAIOSFODNN7EXAMPLE" not in result
+    assert "[REDACTED:aws_access_key]" in result
+
+
+def test_redacts_aws_secret_key():
+    """An AWS secret access key value is replaced; the key name is preserved."""
+    text = 'aws_secret_access_key = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"'
+    result = redact_text(text)
+    assert "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY" not in result
+    assert "[REDACTED:aws_secret_key]" in result
+    assert "aws_secret_access_key" in result
+
+
+def test_redacts_bearer_token():
+    """A Bearer token in an Authorization header is replaced with a placeholder."""
+    text = "Authorization: Bearer abc123DEF456ghi789JKL"
+    result = redact_text(text)
+    assert "abc123DEF456ghi789JKL" not in result
+    assert "[REDACTED:token]" in result
+    assert "Bearer" in result
+
+
+def test_redacts_raw_authorization_header_token():
+    """A raw (non-Bearer) Authorization header value is redacted."""
+    text = "Authorization: abc123def456ghi789jkl"
+    result = redact_text(text)
+    assert "abc123def456ghi789jkl" not in result
+    assert "[REDACTED:token]" in result
+
+
+def test_redacts_github_token():
+    """A GitHub personal access token (ghp_...) is replaced with a placeholder."""
+    text = "token: ghp_1234567890abcdefghijklmnopqrstuvwxyz"
+    result = redact_text(text)
+    assert "ghp_1234567890abcdefghijklmnopqrstuvwxyz" not in result
+    assert "[REDACTED:github_token]" in result
+
+
+def test_redacts_private_key_block():
+    """A PEM private key block is fully replaced with a single placeholder."""
+    text = (
+        "before\n"
+        "-----BEGIN RSA PRIVATE KEY-----\n"
+        "MIIEpAIBAAKCAQEA1234567890abcdefghijklmnop\n"
+        "moreBase64DataHere==\n"
+        "-----END RSA PRIVATE KEY-----\n"
+        "after"
+    )
+    result = redact_text(text)
+    assert "MIIEpAIBAAKCAQEA1234567890abcdefghijklmnop" not in result
+    assert "[REDACTED:private_key]" in result
+    assert "before" in result
+    assert "after" in result
+
+
+def test_redacts_unterminated_private_key_block():
+    """A truncated key block with no END marker is redacted through to the end."""
+    text = (
+        "before context\n"
+        "-----BEGIN RSA PRIVATE KEY-----\n"
+        "MIIEpAIBAAKCAQEA1234567890abcdefghijklmnop\n"
+        "moreBase64DataHereWithoutAnEndMarkerAtAll\n"
+    )
+    result = redact_text(text)
+    assert "MIIEpAIBAAKCAQEA1234567890abcdefghijklmnop" not in result
+    assert "moreBase64DataHereWithoutAnEndMarkerAtAll" not in result
+    assert "[REDACTED:private_key]" in result
+    assert "before context" in result
+
+
+def test_redacts_two_separate_private_key_blocks_independently():
+    """Two separate well-formed key blocks are each redacted, not merged into one."""
+    text = (
+        "-----BEGIN RSA PRIVATE KEY-----\nAAAA1111\n-----END RSA PRIVATE KEY-----\n"
+        "middle text\n"
+        "-----BEGIN RSA PRIVATE KEY-----\nBBBB2222\n-----END RSA PRIVATE KEY-----\n"
+    )
+    result = redact_text(text)
+    assert "AAAA1111" not in result
+    assert "BBBB2222" not in result
+    assert "middle text" in result
+    assert result.count("[REDACTED:private_key]") == 2
+
+
+def test_redacts_email_address():
+    """A plain email address is replaced with the email placeholder."""
+    text = "please reach out to jane.doe@example.com for details"
+    result = redact_text(text)
+    assert "jane.doe@example.com" not in result
+    assert "[REDACTED:email]" in result
+
+
+def test_redacts_password_in_url():
+    """A password embedded in a connection URL is replaced; user/host are kept."""
+    text = "db url: postgres://admin:s3cr3tPassw0rd@db.example.com:5432/mydb"
+    result = redact_text(text)
+    assert "s3cr3tPassw0rd" not in result
+    assert "[REDACTED:password]" in result
+    assert "admin" in result
+    assert "db.example.com" in result
+
+
+# ---------------------------------------------------------------------------
+# Precision: ordinary prose and code identifiers are not over-redacted
+# ---------------------------------------------------------------------------
+
+
+def test_leaves_ordinary_sentence_untouched():
+    """A normal sentence with no secrets is returned unchanged."""
+    text = "The quarterly review is scheduled for next Tuesday afternoon."
+    assert redact_text(text) == text
+
+
+def test_leaves_code_identifiers_untouched():
+    """Ordinary code identifiers that merely resemble secret prefixes are kept."""
+    text = "def sk_ratio(sk_value, aws_region): return sk_value / 2"
+    assert redact_text(text) == text
+
+
+def test_leaves_bearer_word_in_prose_untouched():
+    """The English word 'bearer' followed by ordinary prose is not redacted."""
+    text = "the bearer of this letter should be granted access to the building"
+    assert redact_text(text) == text
+
+
+def test_leaves_short_bearer_like_token_untouched():
+    """A digit-free word after Bearer is not treated as a secret token."""
+    text = "Bearer information"
+    assert redact_text(text) == text
+
+
+def test_leaves_partial_aws_prefix_untouched():
+    """A string that merely starts with AKIA but is not a full key is untouched."""
+    text = "AKIA is not a recognized abbreviation here"
+    assert redact_text(text) == text
+
+
+def test_leaves_url_without_password_untouched():
+    """A URL with no embedded userinfo/password is left unchanged."""
+    text = "see https://example.com/path?query=1 for the report"
+    assert redact_text(text) == text
+
+
+def test_leaves_retina_png_asset_filename_untouched():
+    """A retina-scale @2x.png asset filename is not mistaken for an email."""
+    text = "see icon@2x.png for the retina asset"
+    assert redact_text(text) == text
+
+
+def test_leaves_retina_asset_filename_in_path_untouched():
+    """A retina-scale asset filename embedded in a path is left unchanged."""
+    text = "the file lives at assets/logo@2x.png"
+    assert redact_text(text) == text
+
+
+def test_leaves_retina_jpg_asset_filename_untouched():
+    """A @3x.jpg retina asset filename is not mistaken for an email."""
+    text = "logo@3x.jpg is the exported asset"
+    assert redact_text(text) == text
+
+
+# ---------------------------------------------------------------------------
+# Composite behavior
+# ---------------------------------------------------------------------------
+
+
+def test_redacts_multiple_secrets_and_preserves_surrounding_text():
+    """Multiple distinct secrets in one text are each redacted; prose survives."""
+    text = (
+        "Context: contact ops@example.com if the sk-abcdefghijklmnopqrstuvwx key "
+        "or the AKIAABCDEFGHIJKLMNOP access key stop working."
+    )
+    result = redact_text(text)
+    assert "ops@example.com" not in result
+    assert "sk-abcdefghijklmnopqrstuvwx" not in result
+    assert "AKIAABCDEFGHIJKLMNOP" not in result
+    assert "[REDACTED:email]" in result
+    assert "[REDACTED:api_key]" in result
+    assert "[REDACTED:aws_access_key]" in result
+    assert "Context: contact" in result
+    assert "stop working." in result
+
+
+def test_redact_text_is_deterministic():
+    """Redacting the same input twice yields identical, stable output."""
+    text = "email me at test@example.com"
+    assert redact_text(text) == redact_text(text)
+
+
+def test_redact_text_empty_string():
+    """Empty text is returned unchanged."""
+    assert redact_text("") == ""

--- a/tests/unit/traces/test_envelope_redaction.py
+++ b/tests/unit/traces/test_envelope_redaction.py
@@ -1,0 +1,101 @@
+"""Unit tests for redaction wiring in lerim.traces.envelope.write_compact_trace.
+
+This custom-import path builds its own canonical JSONL independently of
+adapters/common.py's write_session_cache, and previously ran no scrubbing
+at all. These tests exercise that specific wiring rather than the
+redaction patterns themselves (covered in tests/unit/test_redaction.py).
+"""
+
+from __future__ import annotations
+
+import json
+
+from lerim.traces.envelope import NormalizedTrace, write_compact_trace
+
+
+def _trace_with_content(content: str) -> NormalizedTrace:
+    """Build a minimal one-event NormalizedTrace carrying the given content."""
+    event = {
+        "type": "user",
+        "message": {"role": "user", "content": content},
+        "timestamp": None,
+    }
+    return NormalizedTrace(
+        trace_id="trace_test",
+        events=(event,),
+        started_at=None,
+        message_count=1,
+        content_hash="deadbeefcafefeed",
+    )
+
+
+def test_write_compact_trace_redacts_email(tmp_path):
+    """An email address embedded in event content is redacted on write."""
+    trace = _trace_with_content("please email ops@example.com about this")
+    destination = tmp_path / "normalized" / "trace.jsonl"
+
+    write_compact_trace(trace, destination)
+
+    text = destination.read_text(encoding="utf-8")
+    assert "ops@example.com" not in text
+    assert "[REDACTED:email]" in text
+
+
+def test_write_compact_trace_redacts_api_key(tmp_path):
+    """An OpenAI-style API key embedded in event content is redacted on write."""
+    trace = _trace_with_content("here is my key sk-abcdefghijklmnopqrstuvwx0011")
+    destination = tmp_path / "trace.jsonl"
+
+    write_compact_trace(trace, destination)
+
+    text = destination.read_text(encoding="utf-8")
+    assert "sk-abcdefghijklmnopqrstuvwx0011" not in text
+    assert "[REDACTED:api_key]" in text
+
+
+def test_write_compact_trace_redacts_private_key_block(tmp_path):
+    """A private key PEM block embedded in event content is redacted on write."""
+    key_block = (
+        "-----BEGIN RSA PRIVATE KEY-----\n"
+        "MIIEpAIBAAKCAQEA1234567890abcdefghijklmnop\n"
+        "-----END RSA PRIVATE KEY-----"
+    )
+    trace = _trace_with_content(f"rotate this key:\n{key_block}")
+    destination = tmp_path / "trace.jsonl"
+
+    write_compact_trace(trace, destination)
+
+    text = destination.read_text(encoding="utf-8")
+    assert "MIIEpAIBAAKCAQEA1234567890abcdefghijklmnop" not in text
+    assert "[REDACTED:private_key]" in text
+
+
+def test_write_compact_trace_preserves_normal_content(tmp_path):
+    """Event content with no secrets is written through unchanged as valid JSONL."""
+    trace = _trace_with_content("let's ship the release notes tomorrow")
+    destination = tmp_path / "trace.jsonl"
+
+    write_compact_trace(trace, destination)
+
+    lines = destination.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1
+    parsed = json.loads(lines[0])
+    assert parsed["message"]["content"] == "let's ship the release notes tomorrow"
+
+
+def test_write_compact_trace_output_stays_valid_jsonl_after_redaction(tmp_path):
+    """Redaction placeholders keep each line valid, parseable JSON."""
+    trace = _trace_with_content(
+        "contact jane@example.com or use sk-abcdefghijklmnop0000"
+    )
+    destination = tmp_path / "trace.jsonl"
+
+    write_compact_trace(trace, destination)
+
+    lines = [
+        line for line in destination.read_text(encoding="utf-8").splitlines() if line
+    ]
+    assert len(lines) == 1
+    parsed = json.loads(lines[0])
+    assert "[REDACTED:email]" in parsed["message"]["content"]
+    assert "[REDACTED:api_key]" in parsed["message"]["content"]

--- a/uv.lock
+++ b/uv.lock
@@ -2237,7 +2237,7 @@ wheels = [
 
 [[package]]
 name = "lerim"
-version = "0.3.30"
+version = "0.3.31"
 source = { editable = "." }
 dependencies = [
     { name = "dspy" },

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -148,6 +148,7 @@ lerim_context_brief  # noqa
 lerim_working_memory  # noqa
 lerim_context_answer  # noqa
 lerim_context_search  # noqa
+lerim_context_feedback  # noqa
 lerim_records_list  # noqa
 lerim_trace_submit  # noqa
 lerim_ingest_status  # noqa


### PR DESCRIPTION
## What this does

Closes the two open ends of Lerim's memory flywheel identified in a code + market review:

1. **Let Lerim learn which memories are actually good.** Records were extracted once and then trusted equally, forever — no signal ever flowed back about whether a memory was used, confirmed, or flat wrong. This adds a **feedback signal** (`used` / `correct` / `wrong` / `confirm`), turns it into a **per-record earned confidence**, and **folds that confidence into ranking** so good memories rise and bad ones fade.
2. **Make the value visible, and safe to point at real work.** Nothing surfaced where a memory came from, and nothing scrubbed secrets — a pasted API key could be stored verbatim and even written into a committed `CLAUDE.md`/`AGENTS.md`. This adds **secret/PII redaction at the ingestion edge**, a **provenance + earned-confidence view** in the existing dashboard, and **hardens the skill-file editor** to only write evidence-backed text.

## Scope boundary (deliberate)

The **measure-and-auto-optimize-the-extractor** machinery (judge/reward scoring, DSPy optimizer, golden-eval framework) stays **private in `lerim-cloud`** (per commit `b29a555a`). This PR only **captures and uses** the signal in the open runtime, and exposes it cleanly (`lerim feedback`, `api_feedback`, MCP `lerim_context_feedback`) so the private eval can consume it. No scoring/judge logic was added here.

## Changes by area

**Rec 1A — feedback + earned confidence (spine)** — `81cddb6`
- New `record_feedback` table + `records.confidence REAL NOT NULL DEFAULT 0.5` via idempotent additive schema helpers, registered in `_validate_schema`.
- `ContextStore.record_feedback(...)` recomputes confidence with a bounded deterministic formula and applies it via a direct `UPDATE` — **no `record_versions` row, no index-generation bump** (avoids version spam + needless FTS/embedding regen).
- Surfaced end-to-end: `lerim feedback <id> <used|correct|wrong|confirm>` CLI, `POST/GET /api/records/{id}/feedback`, MCP `lerim_context_feedback` (references existing ids only; rejects unknown ids / invalid signals), and the `cloud/shipper.py` read path.

**Rec 1B — earned confidence used in ranking** — `359f4e8`
- `search_records` now fetches candidate metadata *before* the `[:limit]` slice, folds confidence + within-query recency into the score (no longer pure RRF rank-position), corrects `RRF_K` (2 → 60), and adds a calibrated **relevance floor** so retrieval stops returning a top-k when nothing is actually relevant.

**Rec 2A — redaction at the ingestion edge** — `9a9edaf`
- New `src/lerim/redaction.py` (stdlib `re` only, ordered patterns: private-key blocks, passwords-in-URLs, bearer/Authorization tokens, AWS access/secret keys, `sk-`/`ghp_` tokens, emails). Wired into `write_session_cache` (covers all 5 adapters) and `write_compact_trace` (custom-import path).

**Rec 2D — skill-guard hardening** — `75824ed`
- `validate_proposal` now takes an optional `ContextStore` and verifies cited `evidence_record_ids` actually exist and (best-effort) textually support the proposed `after_text`. `AGENTS.md` is first-class when co-located with `SKILL.md`.

**Rec 2B/2C — dashboard provenance + real confidence** — `0e0f7ae`
- Removed the two hardcoded placeholders (`confidence: null`, `avg_confidence: 0`) so real earned confidence renders; added feedback controls and a provenance/lineage view. `tsc --noEmit` passes.

**Docs + test-helper** — `3fd1fcb`, `28dbe5f`
- CHANGELOG, CLI reference (`lerim feedback`), MCP tool list, and `docs/contracts/feedback-and-confidence.md`; registered the new `record_feedback` table in the canonical context-table invariant (`assert_clean_context_schema`).

### Pre-existing bug fixed in passing

Running the real-LLM integration suite (opt-in via `LERIM_INTEGRATION=1`, so it isn't exercised in CI) surfaced a **pre-existing** failure unrelated to this feature: `TRACE_INGESTION_EVENT_NAMES` in `tests/live_helpers.py` had gone stale after `b666e3b` ("Refactor agents to DSPy pipelines") added the `guard_records` / `polish_records` / `annotate_record_roles` stages (plus coding-profile sub-stages) without updating the allowlist. The `assert set(tool_names).issubset(...)` guard therefore fails on `main` too. Synced the allowlist to the pipeline's real stage vocabulary so the suite is green. This is test-helper hygiene, not a change to any shipping code path.

## Testing

- **Unit:** full `tests/unit` green (new: store confidence, retrieval ranking, CLI/API/MCP feedback, redaction ×3, skill-guard evidence, AGENTS.md entry).
- **Static:** `ruff`, `tsc --noEmit`, `mkdocs build --strict` all green.
- **e2e:** `LERIM_E2E=1` — **41/41 passed** (5 hardcoded-skipped), including the CLI/server paths this feature adds.
- **Integration (`trace_ingestion`):** the real-LLM suite (`temperature=1.0`, excluded from CI) has **pre-existing** stochastic failures independent of this feature — see the "Pre-existing bug fixed in passing" note above. This feature's changes are provably absent from the ingestion code path (fixtures load directly; dedup is LLM-manifest-driven, not `search_records`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
