### PR TITLE
ci: auto-create GitHub Release on version tags

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -255,3 +255,41 @@ jobs:
             ghcr.io/lerim-dev/lerim:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  github-release:
+    needs:
+      - publish
+      - docker-push
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Extract release notes from CHANGELOG
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          awk -v ver="## [$version]" \
+            'index($0, ver) == 1 {f=1; next} /^## \[/ {if (f) exit} f' \
+            CHANGELOG.md > release-notes.md
+          if [ ! -s release-notes.md ]; then
+            echo "::error::No CHANGELOG section found for version $version" >&2
+            exit 1
+          fi
+
+      - name: Create or update the GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
+            echo "Release $GITHUB_REF_NAME already exists; updating notes."
+            gh release edit "$GITHUB_REF_NAME" \
+              --notes-file release-notes.md --latest
+          else
+            gh release create "$GITHUB_REF_NAME" \
+              --title "$GITHUB_REF_NAME" \
+              --notes-file release-notes.md \
+              --verify-tag --latest
+          fi


### PR DESCRIPTION
## Problem

`publish.yml` fires on every `v*` tag and automates **PyPI** (Trusted Publishing) + **GHCR** multi-arch Docker images — but it never created a **GitHub Release**. That was a manual step, and it was missed for **v0.3.31** and **v0.3.32**, leaving the Releases page stale at v0.3.30 ("Latest") even though installs were getting 0.3.32.

(The two missing releases have now been backfilled manually.)

## Change

Adds a `github-release` job that:
- runs only after both `publish` (PyPI) and `docker-push` (GHCR) succeed, so the release reflects a fully-shipped version;
- extracts the tag's section from `CHANGELOG.md` (fails loud if absent — `release_preflight` already guarantees it exists);
- creates the release marked **Latest**, or edits notes idempotently on a re-run;
- uses `permissions: contents: write` + the built-in `GITHUB_TOKEN` (no new secrets).

After this lands, a single tag push ships to **PyPI + GHCR + GitHub Releases** in one run.

## Verified
- `publish.yml` parses as valid YAML; job graph intact (`github-release` needs `publish` + `docker-push`).
- The exact awk extraction was run against the current CHANGELOG and produces the correct v0.3.32 notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)